### PR TITLE
Add babel-runtime to fix ReferenceError: regeneratorRuntime

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,6 +10,7 @@
     "react"
   ],
   "plugins": [
+    "transform-runtime",
     "transform-class-properties",
     "transform-es2015-modules-commonjs"
   ]

--- a/README.md
+++ b/README.md
@@ -42,20 +42,6 @@ Your project needs to use React 15.5 or later. If you use older version of React
 
 Add React-PDF to your project by executing `npm install --save react-pdf`.
 
-### babel-polyfill
-
-If you use babel-polyfill, make sure to require it before `react-pdf`.
-
-If you can't do that, before requiring, check if it has not been required beforehand, otherwise you will get an error *Uncaught Error: only one instance of babel-polyfill is allowed*. You can check that by writing the following:
-
-```js
-if (!window._babelPolyfill) {
-  require('babel-polyfill');
-}
-```
-
-If you don't use babel-polyfill, you're all set - React-PDF will require it for you just before it's needed.
-
 ### Usage
 
 Here's an example of basic usage:

--- a/build/Document.js
+++ b/build/Document.js
@@ -4,9 +4,37 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+var _typeof2 = require('babel-runtime/helpers/typeof');
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+var _typeof3 = _interopRequireDefault(_typeof2);
+
+var _assign = require('babel-runtime/core-js/object/assign');
+
+var _assign2 = _interopRequireDefault(_assign);
+
+var _promise = require('babel-runtime/core-js/promise');
+
+var _promise2 = _interopRequireDefault(_promise);
+
+var _getPrototypeOf = require('babel-runtime/core-js/object/get-prototype-of');
+
+var _getPrototypeOf2 = _interopRequireDefault(_getPrototypeOf);
+
+var _classCallCheck2 = require('babel-runtime/helpers/classCallCheck');
+
+var _classCallCheck3 = _interopRequireDefault(_classCallCheck2);
+
+var _createClass2 = require('babel-runtime/helpers/createClass');
+
+var _createClass3 = _interopRequireDefault(_createClass2);
+
+var _possibleConstructorReturn2 = require('babel-runtime/helpers/possibleConstructorReturn');
+
+var _possibleConstructorReturn3 = _interopRequireDefault(_possibleConstructorReturn2);
+
+var _inherits2 = require('babel-runtime/helpers/inherits');
+
+var _inherits3 = _interopRequireDefault(_inherits2);
 
 var _react = require('react');
 
@@ -20,30 +48,21 @@ var _util = require('./shared/util');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; } /**
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                * Loads a PDF document. Passes it to all children.
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                */
-
-
 var Document = function (_Component) {
-  _inherits(Document, _Component);
+  (0, _inherits3.default)(Document, _Component);
 
   function Document() {
     var _ref;
 
     var _temp, _this, _ret;
 
-    _classCallCheck(this, Document);
+    (0, _classCallCheck3.default)(this, Document);
 
     for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
       args[_key] = arguments[_key];
     }
 
-    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Document.__proto__ || Object.getPrototypeOf(Document)).call.apply(_ref, [this].concat(args))), _this), _this.state = {
+    return _ret = (_temp = (_this = (0, _possibleConstructorReturn3.default)(this, (_ref = Document.__proto__ || (0, _getPrototypeOf2.default)(Document)).call.apply(_ref, [this].concat(args))), _this), _this.state = {
       pdf: null
     }, _this.onSourceSuccess = function (source) {
       (0, _util.callIfDefined)(_this.props.onSourceSuccess);
@@ -83,7 +102,7 @@ var Document = function (_Component) {
       _this.setState({ pdf: false });
     }, _this.findDocumentSource = function () {
       var props = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : _this.props;
-      return new Promise(function (resolve, reject) {
+      return new _promise2.default(function (resolve, reject) {
         var file = props.file;
 
 
@@ -110,7 +129,7 @@ var Document = function (_Component) {
 
         if ((0, _util.isParamObject)(file)) {
           // Prevent from modifying props
-          var modifiedFile = Object.assign({}, file);
+          var modifiedFile = (0, _assign2.default)({}, file);
 
           if ('url' in modifiedFile) {
             // File is data URI
@@ -150,10 +169,10 @@ var Document = function (_Component) {
         // No supported loading method worked
         return reject();
       });
-    }, _temp), _possibleConstructorReturn(_this, _ret);
+    }, _temp), (0, _possibleConstructorReturn3.default)(_this, _ret);
   }
 
-  _createClass(Document, [{
+  (0, _createClass3.default)(Document, [{
     key: 'componentDidMount',
     value: function componentDidMount() {
       this.loadDocument();
@@ -210,7 +229,7 @@ var Document = function (_Component) {
       }
 
       // We got file of different type - clearly there's been a change
-      if ((typeof nextFile === 'undefined' ? 'undefined' : _typeof(nextFile)) !== (typeof file === 'undefined' ? 'undefined' : _typeof(file))) {
+      if ((typeof nextFile === 'undefined' ? 'undefined' : (0, _typeof3.default)(nextFile)) !== (typeof file === 'undefined' ? 'undefined' : (0, _typeof3.default)(file))) {
         return true;
       }
 
@@ -303,9 +322,11 @@ var Document = function (_Component) {
       return this.renderChildren();
     }
   }]);
-
   return Document;
-}(_react.Component);
+}(_react.Component); /**
+                      * Loads a PDF document. Passes it to all children.
+                      */
+
 
 exports.default = Document;
 

--- a/build/Outline.js
+++ b/build/Outline.js
@@ -4,9 +4,41 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
+var _promise = require('babel-runtime/core-js/promise');
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+var _promise2 = _interopRequireDefault(_promise);
+
+var _slicedToArray2 = require('babel-runtime/helpers/slicedToArray');
+
+var _slicedToArray3 = _interopRequireDefault(_slicedToArray2);
+
+var _regenerator = require('babel-runtime/regenerator');
+
+var _regenerator2 = _interopRequireDefault(_regenerator);
+
+var _asyncToGenerator2 = require('babel-runtime/helpers/asyncToGenerator');
+
+var _asyncToGenerator3 = _interopRequireDefault(_asyncToGenerator2);
+
+var _getPrototypeOf = require('babel-runtime/core-js/object/get-prototype-of');
+
+var _getPrototypeOf2 = _interopRequireDefault(_getPrototypeOf);
+
+var _possibleConstructorReturn2 = require('babel-runtime/helpers/possibleConstructorReturn');
+
+var _possibleConstructorReturn3 = _interopRequireDefault(_possibleConstructorReturn2);
+
+var _inherits2 = require('babel-runtime/helpers/inherits');
+
+var _inherits3 = _interopRequireDefault(_inherits2);
+
+var _classCallCheck2 = require('babel-runtime/helpers/classCallCheck');
+
+var _classCallCheck3 = _interopRequireDefault(_classCallCheck2);
+
+var _createClass2 = require('babel-runtime/helpers/createClass');
+
+var _createClass3 = _interopRequireDefault(_createClass2);
 
 var _react = require('react');
 
@@ -20,14 +52,6 @@ var _util = require('./shared/util');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
-
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
 // eslint-disable-next-line no-underscore-dangle
 if (!window._babelPolyfill) {
   // eslint-disable-next-line global-require
@@ -38,14 +62,13 @@ var Ref = function () {
   function Ref(_ref) {
     var num = _ref.num,
         gen = _ref.gen;
-
-    _classCallCheck(this, Ref);
+    (0, _classCallCheck3.default)(this, Ref);
 
     this.num = num;
     this.gen = gen;
   }
 
-  _createClass(Ref, [{
+  (0, _createClass3.default)(Ref, [{
     key: 'toString',
     value: function toString() {
       var str = this.num + 'R';
@@ -55,25 +78,24 @@ var Ref = function () {
       return str;
     }
   }]);
-
   return Ref;
 }();
 
 var Outline = function (_Component) {
-  _inherits(Outline, _Component);
+  (0, _inherits3.default)(Outline, _Component);
 
   function Outline() {
     var _ref2;
 
     var _temp, _this, _ret;
 
-    _classCallCheck(this, Outline);
+    (0, _classCallCheck3.default)(this, Outline);
 
     for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
       args[_key] = arguments[_key];
     }
 
-    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref2 = Outline.__proto__ || Object.getPrototypeOf(Outline)).call.apply(_ref2, [this].concat(args))), _this), _this.state = {
+    return _ret = (_temp = (_this = (0, _possibleConstructorReturn3.default)(this, (_ref2 = Outline.__proto__ || (0, _getPrototypeOf2.default)(Outline)).call.apply(_ref2, [this].concat(args))), _this), _this.state = {
       outline: null
     }, _this.onLoadSuccess = function (outline) {
       (0, _util.callIfDefined)(_this.props.onLoadSuccess);
@@ -103,10 +125,10 @@ var Outline = function (_Component) {
       (0, _util.callIfDefined)(_this.props.onParseError, error);
 
       _this.setState({ outline: false });
-    }, _temp), _possibleConstructorReturn(_this, _ret);
+    }, _temp), (0, _possibleConstructorReturn3.default)(_this, _ret);
   }
 
-  _createClass(Outline, [{
+  (0, _createClass3.default)(Outline, [{
     key: 'componentDidMount',
     value: function componentDidMount() {
       this.loadOutline();
@@ -143,11 +165,11 @@ var Outline = function (_Component) {
   }, {
     key: 'mapOutlineItem',
     value: function () {
-      var _ref3 = _asyncToGenerator(regeneratorRuntime.mark(function _callee4(item) {
+      var _ref3 = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee4(item) {
         var _this5 = this;
 
         var pdf, mappedItem;
-        return regeneratorRuntime.wrap(function _callee4$(_context4) {
+        return _regenerator2.default.wrap(function _callee4$(_context4) {
           while (1) {
             switch (_context4.prev = _context4.next) {
               case 0:
@@ -158,8 +180,8 @@ var Outline = function (_Component) {
                   getDestination: function getDestination() {
                     var _this2 = this;
 
-                    return _asyncToGenerator(regeneratorRuntime.mark(function _callee() {
-                      return regeneratorRuntime.wrap(function _callee$(_context) {
+                    return (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee() {
+                      return _regenerator2.default.wrap(function _callee$(_context) {
                         while (1) {
                           switch (_context.prev = _context.next) {
                             case 0:
@@ -184,10 +206,10 @@ var Outline = function (_Component) {
                   getPageIndex: function getPageIndex() {
                     var _this3 = this;
 
-                    return _asyncToGenerator(regeneratorRuntime.mark(function _callee2() {
+                    return (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee2() {
                       var destination, _destination, ref;
 
-                      return regeneratorRuntime.wrap(function _callee2$(_context2) {
+                      return _regenerator2.default.wrap(function _callee2$(_context2) {
                         while (1) {
                           switch (_context2.prev = _context2.next) {
                             case 0:
@@ -203,7 +225,7 @@ var Outline = function (_Component) {
                               destination = _context2.sent;
 
                               if (destination) {
-                                _destination = _slicedToArray(destination, 1), ref = _destination[0];
+                                _destination = (0, _slicedToArray3.default)(destination, 1), ref = _destination[0];
 
                                 _this3.pageIndex = pdf.getPageIndex(new Ref(ref));
                               }
@@ -222,8 +244,8 @@ var Outline = function (_Component) {
                   getPageNumber: function getPageNumber() {
                     var _this4 = this;
 
-                    return _asyncToGenerator(regeneratorRuntime.mark(function _callee3() {
-                      return regeneratorRuntime.wrap(function _callee3$(_context3) {
+                    return (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee3() {
+                      return _regenerator2.default.wrap(function _callee3$(_context3) {
                         while (1) {
                           switch (_context3.prev = _context3.next) {
                             case 0:
@@ -258,7 +280,7 @@ var Outline = function (_Component) {
                 }
 
                 _context4.next = 5;
-                return Promise.all(item.items.map(function (subitem) {
+                return _promise2.default.all(item.items.map(function (subitem) {
                   return _this5.mapOutlineItem(subitem);
                 }));
 
@@ -285,10 +307,10 @@ var Outline = function (_Component) {
   }, {
     key: 'parseOutline',
     value: function () {
-      var _ref4 = _asyncToGenerator(regeneratorRuntime.mark(function _callee5(outline) {
+      var _ref4 = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee5(outline) {
         var _this6 = this;
 
-        return regeneratorRuntime.wrap(function _callee5$(_context5) {
+        return _regenerator2.default.wrap(function _callee5$(_context5) {
           while (1) {
             switch (_context5.prev = _context5.next) {
               case 0:
@@ -300,7 +322,7 @@ var Outline = function (_Component) {
                 return _context5.abrupt('return', null);
 
               case 2:
-                return _context5.abrupt('return', Promise.all(outline.map(function (item) {
+                return _context5.abrupt('return', _promise2.default.all(outline.map(function (item) {
                   return _this6.mapOutlineItem(item);
                 })));
 
@@ -321,9 +343,9 @@ var Outline = function (_Component) {
   }, {
     key: 'onItemClick',
     value: function () {
-      var _ref5 = _asyncToGenerator(regeneratorRuntime.mark(function _callee6(item) {
+      var _ref5 = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee6(item) {
         var pageIndex, pageNumber;
-        return regeneratorRuntime.wrap(function _callee6$(_context6) {
+        return _regenerator2.default.wrap(function _callee6$(_context6) {
           while (1) {
             switch (_context6.prev = _context6.next) {
               case 0:
@@ -428,7 +450,6 @@ var Outline = function (_Component) {
       );
     }
   }]);
-
   return Outline;
 }(_react.Component);
 

--- a/build/Outline.js
+++ b/build/Outline.js
@@ -52,12 +52,6 @@ var _util = require('./shared/util');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-// eslint-disable-next-line no-underscore-dangle
-if (!window._babelPolyfill) {
-  // eslint-disable-next-line global-require
-  require('babel-polyfill');
-}
-
 var Ref = function () {
   function Ref(_ref) {
     var num = _ref.num,
@@ -165,7 +159,7 @@ var Outline = function (_Component) {
   }, {
     key: 'mapOutlineItem',
     value: function () {
-      var _ref3 = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee4(item) {
+      var _ref3 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee4(item) {
         var _this5 = this;
 
         var pdf, mappedItem;
@@ -180,7 +174,7 @@ var Outline = function (_Component) {
                   getDestination: function getDestination() {
                     var _this2 = this;
 
-                    return (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee() {
+                    return (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee() {
                       return _regenerator2.default.wrap(function _callee$(_context) {
                         while (1) {
                           switch (_context.prev = _context.next) {
@@ -206,7 +200,7 @@ var Outline = function (_Component) {
                   getPageIndex: function getPageIndex() {
                     var _this3 = this;
 
-                    return (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee2() {
+                    return (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee2() {
                       var destination, _destination, ref;
 
                       return _regenerator2.default.wrap(function _callee2$(_context2) {
@@ -244,7 +238,7 @@ var Outline = function (_Component) {
                   getPageNumber: function getPageNumber() {
                     var _this4 = this;
 
-                    return (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee3() {
+                    return (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee3() {
                       return _regenerator2.default.wrap(function _callee3$(_context3) {
                         while (1) {
                           switch (_context3.prev = _context3.next) {
@@ -307,7 +301,7 @@ var Outline = function (_Component) {
   }, {
     key: 'parseOutline',
     value: function () {
-      var _ref4 = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee5(outline) {
+      var _ref4 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee5(outline) {
         var _this6 = this;
 
         return _regenerator2.default.wrap(function _callee5$(_context5) {
@@ -343,7 +337,7 @@ var Outline = function (_Component) {
   }, {
     key: 'onItemClick',
     value: function () {
-      var _ref5 = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee6(item) {
+      var _ref5 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee6(item) {
         var pageIndex, pageNumber;
         return _regenerator2.default.wrap(function _callee6$(_context6) {
           while (1) {

--- a/build/Page.js
+++ b/build/Page.js
@@ -4,9 +4,29 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+var _extends2 = require('babel-runtime/helpers/extends');
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+var _extends3 = _interopRequireDefault(_extends2);
+
+var _getPrototypeOf = require('babel-runtime/core-js/object/get-prototype-of');
+
+var _getPrototypeOf2 = _interopRequireDefault(_getPrototypeOf);
+
+var _classCallCheck2 = require('babel-runtime/helpers/classCallCheck');
+
+var _classCallCheck3 = _interopRequireDefault(_classCallCheck2);
+
+var _createClass2 = require('babel-runtime/helpers/createClass');
+
+var _createClass3 = _interopRequireDefault(_createClass2);
+
+var _possibleConstructorReturn2 = require('babel-runtime/helpers/possibleConstructorReturn');
+
+var _possibleConstructorReturn3 = _interopRequireDefault(_possibleConstructorReturn2);
+
+var _inherits2 = require('babel-runtime/helpers/inherits');
+
+var _inherits3 = _interopRequireDefault(_inherits2);
 
 var _react = require('react');
 
@@ -28,27 +48,21 @@ var _util = require('./shared/util');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
 var Page = function (_Component) {
-  _inherits(Page, _Component);
+  (0, _inherits3.default)(Page, _Component);
 
   function Page() {
     var _ref;
 
     var _temp, _this, _ret;
 
-    _classCallCheck(this, Page);
+    (0, _classCallCheck3.default)(this, Page);
 
     for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
       args[_key] = arguments[_key];
     }
 
-    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Page.__proto__ || Object.getPrototypeOf(Page)).call.apply(_ref, [this].concat(args))), _this), _this.state = {
+    return _ret = (_temp = (_this = (0, _possibleConstructorReturn3.default)(this, (_ref = Page.__proto__ || (0, _getPrototypeOf2.default)(Page)).call.apply(_ref, [this].concat(args))), _this), _this.state = {
       page: null
     }, _this.onLoadSuccess = function (page) {
       _this.setState({ page: page });
@@ -57,7 +71,7 @@ var Page = function (_Component) {
           scale = _this2.scale;
 
 
-      (0, _util.callIfDefined)(_this.props.onLoadSuccess, _extends({}, page, {
+      (0, _util.callIfDefined)(_this.props.onLoadSuccess, (0, _extends3.default)({}, page, {
         // Legacy callback params
         get width() {
           return page.view[2] * scale;
@@ -77,10 +91,10 @@ var Page = function (_Component) {
       (0, _util.callIfDefined)(_this.props.onLoadError, error);
 
       _this.setState({ page: false });
-    }, _temp), _possibleConstructorReturn(_this, _ret);
+    }, _temp), (0, _possibleConstructorReturn3.default)(_this, _ret);
   }
 
-  _createClass(Page, [{
+  (0, _createClass3.default)(Page, [{
     key: 'componentDidMount',
     value: function componentDidMount() {
       this.loadPage();
@@ -251,7 +265,6 @@ var Page = function (_Component) {
       return scale * pageScale;
     }
   }]);
-
   return Page;
 }(_react.Component);
 

--- a/build/PageCanvas.js
+++ b/build/PageCanvas.js
@@ -4,7 +4,25 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+var _getPrototypeOf = require('babel-runtime/core-js/object/get-prototype-of');
+
+var _getPrototypeOf2 = _interopRequireDefault(_getPrototypeOf);
+
+var _classCallCheck2 = require('babel-runtime/helpers/classCallCheck');
+
+var _classCallCheck3 = _interopRequireDefault(_classCallCheck2);
+
+var _createClass2 = require('babel-runtime/helpers/createClass');
+
+var _createClass3 = _interopRequireDefault(_createClass2);
+
+var _possibleConstructorReturn2 = require('babel-runtime/helpers/possibleConstructorReturn');
+
+var _possibleConstructorReturn3 = _interopRequireDefault(_possibleConstructorReturn2);
+
+var _inherits2 = require('babel-runtime/helpers/inherits');
+
+var _inherits3 = _interopRequireDefault(_inherits2);
 
 var _react = require('react');
 
@@ -18,27 +36,21 @@ var _util = require('./shared/util');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
 var PageCanvas = function (_Component) {
-  _inherits(PageCanvas, _Component);
+  (0, _inherits3.default)(PageCanvas, _Component);
 
   function PageCanvas() {
     var _ref;
 
     var _temp, _this, _ret;
 
-    _classCallCheck(this, PageCanvas);
+    (0, _classCallCheck3.default)(this, PageCanvas);
 
     for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
       args[_key] = arguments[_key];
     }
 
-    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = PageCanvas.__proto__ || Object.getPrototypeOf(PageCanvas)).call.apply(_ref, [this].concat(args))), _this), _this.onRenderSuccess = function () {
+    return _ret = (_temp = (_this = (0, _possibleConstructorReturn3.default)(this, (_ref = PageCanvas.__proto__ || (0, _getPrototypeOf2.default)(PageCanvas)).call.apply(_ref, [this].concat(args))), _this), _this.onRenderSuccess = function () {
       _this.renderer = null;
 
       (0, _util.callIfDefined)(_this.props.onRenderSuccess);
@@ -85,7 +97,7 @@ var PageCanvas = function (_Component) {
 
         _this.onRenderError(error);
       });
-    }, _temp), _possibleConstructorReturn(_this, _ret);
+    }, _temp), (0, _possibleConstructorReturn3.default)(_this, _ret);
   }
   /**
    * Called when a page is rendered successfully.
@@ -97,7 +109,7 @@ var PageCanvas = function (_Component) {
    */
 
 
-  _createClass(PageCanvas, [{
+  (0, _createClass3.default)(PageCanvas, [{
     key: 'render',
     value: function render() {
       var _this3 = this;
@@ -140,7 +152,6 @@ var PageCanvas = function (_Component) {
       return page.getViewport(scale, rotate);
     }
   }]);
-
   return PageCanvas;
 }(_react.Component);
 

--- a/build/PageTextContent.js
+++ b/build/PageTextContent.js
@@ -4,9 +4,37 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
+var _regenerator = require('babel-runtime/regenerator');
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+var _regenerator2 = _interopRequireDefault(_regenerator);
+
+var _asyncToGenerator2 = require('babel-runtime/helpers/asyncToGenerator');
+
+var _asyncToGenerator3 = _interopRequireDefault(_asyncToGenerator2);
+
+var _slicedToArray2 = require('babel-runtime/helpers/slicedToArray');
+
+var _slicedToArray3 = _interopRequireDefault(_slicedToArray2);
+
+var _getPrototypeOf = require('babel-runtime/core-js/object/get-prototype-of');
+
+var _getPrototypeOf2 = _interopRequireDefault(_getPrototypeOf);
+
+var _classCallCheck2 = require('babel-runtime/helpers/classCallCheck');
+
+var _classCallCheck3 = _interopRequireDefault(_classCallCheck2);
+
+var _createClass2 = require('babel-runtime/helpers/createClass');
+
+var _createClass3 = _interopRequireDefault(_createClass2);
+
+var _possibleConstructorReturn2 = require('babel-runtime/helpers/possibleConstructorReturn');
+
+var _possibleConstructorReturn3 = _interopRequireDefault(_possibleConstructorReturn2);
+
+var _inherits2 = require('babel-runtime/helpers/inherits');
+
+var _inherits3 = _interopRequireDefault(_inherits2);
 
 var _react = require('react');
 
@@ -20,14 +48,6 @@ var _util = require('./shared/util');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
 // eslint-disable-next-line no-underscore-dangle
 if (!window._babelPolyfill) {
   // eslint-disable-next-line global-require
@@ -38,20 +58,20 @@ if (!window._babelPolyfill) {
 var BROKEN_FONT_ALARM_THRESHOLD = 0.1;
 
 var PageTextContent = function (_Component) {
-  _inherits(PageTextContent, _Component);
+  (0, _inherits3.default)(PageTextContent, _Component);
 
   function PageTextContent() {
     var _ref;
 
     var _temp, _this, _ret;
 
-    _classCallCheck(this, PageTextContent);
+    (0, _classCallCheck3.default)(this, PageTextContent);
 
     for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
       args[_key] = arguments[_key];
     }
 
-    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = PageTextContent.__proto__ || Object.getPrototypeOf(PageTextContent)).call.apply(_ref, [this].concat(args))), _this), _this.state = {
+    return _ret = (_temp = (_this = (0, _possibleConstructorReturn3.default)(this, (_ref = PageTextContent.__proto__ || (0, _getPrototypeOf2.default)(PageTextContent)).call.apply(_ref, [this].concat(args))), _this), _this.state = {
       textItems: null
     }, _this.onGetTextSuccess = function (textContent) {
       var textItems = null;
@@ -67,7 +87,7 @@ var PageTextContent = function (_Component) {
 
       _this.setState({ textItems: false });
     }, _this.renderTextItem = function (textItem, itemIndex) {
-      var _textItem$transform = _slicedToArray(textItem.transform, 6),
+      var _textItem$transform = (0, _slicedToArray3.default)(textItem.transform, 6),
           fontSizePx = _textItem$transform[0],
           left = _textItem$transform[4],
           baselineBottom = _textItem$transform[5];
@@ -103,10 +123,10 @@ var PageTextContent = function (_Component) {
         },
         textItem.str
       );
-    }, _temp), _possibleConstructorReturn(_this, _ret);
+    }, _temp), (0, _possibleConstructorReturn3.default)(_this, _ret);
   }
 
-  _createClass(PageTextContent, [{
+  (0, _createClass3.default)(PageTextContent, [{
     key: 'componentDidMount',
     value: function componentDidMount() {
       this.getTextContent();
@@ -138,9 +158,9 @@ var PageTextContent = function (_Component) {
   }, {
     key: 'getFontData',
     value: function () {
-      var _ref3 = _asyncToGenerator(regeneratorRuntime.mark(function _callee(fontFamily) {
+      var _ref3 = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee(fontFamily) {
         var page, font;
-        return regeneratorRuntime.wrap(function _callee$(_context) {
+        return _regenerator2.default.wrap(function _callee$(_context) {
           while (1) {
             switch (_context.prev = _context.next) {
               case 0:
@@ -169,9 +189,9 @@ var PageTextContent = function (_Component) {
   }, {
     key: 'alignTextItem',
     value: function () {
-      var _ref4 = _asyncToGenerator(regeneratorRuntime.mark(function _callee2(element, textItem) {
+      var _ref4 = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee2(element, textItem) {
         var scale, targetWidth, fontData, actualWidth, widthDisproportion, repairsNeeded, fallbackFontName, ascent;
-        return regeneratorRuntime.wrap(function _callee2$(_context2) {
+        return _regenerator2.default.wrap(function _callee2$(_context2) {
           while (1) {
             switch (_context2.prev = _context2.next) {
               case 0:
@@ -268,7 +288,6 @@ var PageTextContent = function (_Component) {
       return page.getViewport(scale);
     }
   }]);
-
   return PageTextContent;
 }(_react.Component);
 

--- a/build/PageTextContent.js
+++ b/build/PageTextContent.js
@@ -48,12 +48,6 @@ var _util = require('./shared/util');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-// eslint-disable-next-line no-underscore-dangle
-if (!window._babelPolyfill) {
-  // eslint-disable-next-line global-require
-  require('babel-polyfill');
-}
-
 // Render disproportion above which font will be considered broken and fallback will be used
 var BROKEN_FONT_ALARM_THRESHOLD = 0.1;
 
@@ -158,7 +152,7 @@ var PageTextContent = function (_Component) {
   }, {
     key: 'getFontData',
     value: function () {
-      var _ref3 = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee(fontFamily) {
+      var _ref3 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee(fontFamily) {
         var page, font;
         return _regenerator2.default.wrap(function _callee$(_context) {
           while (1) {
@@ -189,7 +183,7 @@ var PageTextContent = function (_Component) {
   }, {
     key: 'alignTextItem',
     value: function () {
-      var _ref4 = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee2(element, textItem) {
+      var _ref4 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee2(element, textItem) {
         var scale, targetWidth, fontData, actualWidth, widthDisproportion, repairsNeeded, fallbackFontName, ascent;
         return _regenerator2.default.wrap(function _callee2$(_context2) {
           while (1) {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "babel-polyfill": "^6.23.0",
+    "babel-runtime": "^6.25.0",
     "pdfjs-dist": "^1.8.618",
     "prop-types": ">=15.5",
     "react": ">=15.5",
@@ -43,6 +44,7 @@
     "babel-eslint": "^7.2.3",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "babel-polyfill": "^6.23.0",
     "babel-runtime": "^6.25.0",
     "pdfjs-dist": "^1.8.618",
     "prop-types": ">=15.5",

--- a/src/Outline.jsx
+++ b/src/Outline.jsx
@@ -7,12 +7,6 @@ import {
   makeCancellable,
 } from './shared/util';
 
-// eslint-disable-next-line no-underscore-dangle
-if (!window._babelPolyfill) {
-  // eslint-disable-next-line global-require
-  require('babel-polyfill');
-}
-
 class Ref {
   constructor({ num, gen }) {
     this.num = num;

--- a/src/PageTextContent.jsx
+++ b/src/PageTextContent.jsx
@@ -5,12 +5,6 @@ import {
   callIfDefined,
 } from './shared/util';
 
-// eslint-disable-next-line no-underscore-dangle
-if (!window._babelPolyfill) {
-  // eslint-disable-next-line global-require
-  require('babel-polyfill');
-}
-
 // Render disproportion above which font will be considered broken and fallback will be used
 const BROKEN_FONT_ALARM_THRESHOLD = 0.1;
 


### PR DESCRIPTION
After several tests I found the fix of this issue. It's needed to add the `babel-runtime` environment.

https://babeljs.io/docs/plugins/transform-runtime/

I tried to change the location of the `require('babel-polyfill')` but it didn't fix my issue. Anyway, it's a best practice to require it once at the top of your entry file.

Fixes #39 

PS: You shouldn't push your build files to GitHub :)