### PR TITLE
Respect onClick, className and other properties passed to Page and Document

### DIFF
--- a/src/Document.jsx
+++ b/src/Document.jsx
@@ -231,7 +231,7 @@ export default class Document extends Component {
   }
 
   renderChildren() {
-    const { children, rotate } = this.props;
+    const { children, rotate, className } = this.props;
     const { pdf } = this.state;
 
     const childProps = {
@@ -240,7 +240,7 @@ export default class Document extends Component {
     };
 
     return (
-      <div className="ReactPDF__Document">
+      <div className={`ReactPDF__Document ${className}`}>
         {
           children && Children
             .map(children, child => React.cloneElement(child, childProps))

--- a/src/Page.jsx
+++ b/src/Page.jsx
@@ -153,7 +153,23 @@ export default class Page extends Component {
   }
 
   render() {
-    const { pdf } = this.props;
+    const {
+      onGetTextError,
+      onGetTextSuccess,
+      onRenderError,
+      onRenderSuccess,
+      renderTextLayer,
+      className,
+      pdf,
+      scale,  // consume all props for ...other
+      width,  // consume all props for ...other
+      rotate, // consume all props for ...other
+      onLoadError,  // consume all props for ...other
+      onLoadSuccess,// consume all props for ...other
+      pageNumber,   // consume all props for ...other
+      ...other
+     } = this.props;
+
     const { page } = this.state;
     const { pageIndex } = this;
 
@@ -165,17 +181,10 @@ export default class Page extends Component {
       return null;
     }
 
-    const {
-      onGetTextError,
-      onGetTextSuccess,
-      onRenderError,
-      onRenderSuccess,
-      renderTextLayer,
-     } = this.props;
-
     return (
       <div
-        className="ReactPDF__Page"
+        {...other}
+        className={`ReactPDF__Page ${className}`}
         style={{ position: 'relative' }}
       >
         <PageCanvas
@@ -222,4 +231,5 @@ Page.propTypes = {
   rotate: PropTypes.number,
   scale: PropTypes.number,
   width: PropTypes.number,
+  className: PropTypes.string,
 };


### PR DESCRIPTION
Having onClick and onMouseOver callbacks on Page components enables flashy javascript behaviors like zoom and being able to fullsize a thumbnail preview.

Respecting className properties passed to Page and Document makes styling much easier - especially with modern css grids (Bootstrap).

- Updated Document to include any className passed to the component in the top level div it outputs.
- Updated Page to include both the className and any property it doesn't consume itself. 

I used the ...other operator to pass props to the top level div, see https://zhenyong.github.io/react/docs/transferring-props.html for details.  Doing it this way involves including several properties in render() that aren't actually used by that function. I think this is the most forward compatible option since extra any property the user passes in will just be passed along (Bonus if they mistype a prop name they'll get an error). If you really don't like this solution listing all component props is an alternative, though I have not been able to find a comprehensive list...

Anywho, I hope you find these useful improvements :)