### PR TITLE
Add scale to PageCanvas key property

### DIFF
--- a/src/Page.jsx
+++ b/src/Page.jsx
@@ -201,7 +201,7 @@ export default class Page extends Component {
         {...this.eventProps}
       >
         <PageCanvas
-          key={`${page.pageIndex}@${rotate}_canvas`}
+          key={`${page.pageIndex}@${rotate}_canvas@${scale}_canvas`}
           onRenderError={onRenderError}
           onRenderSuccess={onRenderSuccess}
           page={page}


### PR DESCRIPTION
Relates to https://github.com/wojtekmaj/react-pdf/issues/74
### Description
The issue was in `drawPageOnCanvas` function from `PageCanvas` component not being invoked when a `scale` property changed. It was invoked only once during initial component render.

Adding `scale` to `key` property of PageCanvas forces React to replace component as you've suggested in original issue.
