### PR TITLE
Move react and react-dom to peer dependencies. Add React 16 version string.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,7 @@
     "prepublishOnly": "npm run build",
     "test": "npm run eslint"
   },
-  "keywords": [
-    "pdf",
-    "pdf-viewer",
-    "react"
-  ],
+  "keywords": ["pdf", "pdf-viewer", "react"],
   "author": {
     "name": "Wojciech Maj",
     "email": "kontakt@wojtekmaj.pl"
@@ -36,8 +32,6 @@
     "merge-class-names": "^1.1.0",
     "pdfjs-dist": "^1.9.617",
     "prop-types": ">=15.5",
-    "react": ">=15.5",
-    "react-dom": ">=15.5",
     "webpack": "^3.6.0"
   },
   "devDependencies": {
@@ -57,12 +51,11 @@
     "eslint-plugin-jsx-a11y": "^5.1.1",
     "eslint-plugin-react": "^7.4.0"
   },
-  "files": [
-    "LICENSE",
-    "README.md",
-    "build/",
-    "src/"
-  ],
+  "peerDependencies": {
+    "react": "^15.5.0 || ^16.0.0",
+    "react-dom": "^15.5.0 || ^16.0.0"
+  },
+  "files": ["LICENSE", "README.md", "build/", "src/"],
   "repository": {
     "type": "git",
     "url": "https://github.com/wojtekmaj/react-pdf.git"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2471,7 +2471,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -2919,7 +2919,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@>=15.5, prop-types@^15.6.0:
+prop-types@>=15.5:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -2993,24 +2993,6 @@ rc@^1.1.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
-
-react-dom@>=15.5:
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.0.0.tgz#9cc3079c3dcd70d4c6e01b84aab2a7e34c303f58"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
-
-react@>=15.5:
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.0.0.tgz#ce7df8f1941b036f02b2cca9dbd0cb1f0e855e2d"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
 
 read-pkg-up@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Reasonably self explanatory; as this is a React-dependent plugin, makes much more sense for `react` & `react-dom` to be peer dependencies.