### PR TITLE
Move dev dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,13 +43,13 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "babel-runtime": "^6.26.0",
     "lodash.once": "^4.1.1",
     "merge-class-names": "^1.1.0",
     "pdfjs-dist": "^1.9.617",
     "prop-types": ">=15.5"
   },
   "devDependencies": {
-    "babel-runtime": "^6.26.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -43,14 +43,13 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "babel-runtime": "^6.26.0",
     "lodash.once": "^4.1.1",
     "merge-class-names": "^1.1.0",
     "pdfjs-dist": "^1.9.617",
-    "prop-types": ">=15.5",
-    "webpack": "^3.6.0"
+    "prop-types": ">=15.5"
   },
   "devDependencies": {
+    "babel-runtime": "^6.26.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.0.1",
@@ -65,7 +64,8 @@
     "eslint-plugin-class-property": "^1.0.6",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-jsx-a11y": "^5.1.1",
-    "eslint-plugin-react": "^7.4.0"
+    "eslint-plugin-react": "^7.4.0",
+    "webpack": "^3.6.0"
   },
   "peerDependencies": {
     "react": "^15.5.0 || ^16.0.0",


### PR DESCRIPTION
Thanks for the package!

Something should be said about managing dependencies though.

* If a dependency is consumed in applications & is also a singleton package, it needs to be a `peerDependency` (eg. React)
* If a dependency isn't consumed by applications, but it's used in the development of this package, then it needs to be a `devDependency`

These guidelines are universal in npm. I realise that not everyone is familiar with the nitty-gritties of dependency discipline, but this are some of the basics that make the rest of the ecosystem work.

Again, thanks!