### PR TITLE
Render text layer above annotation layer

### DIFF
--- a/src/Page.jsx
+++ b/src/Page.jsx
@@ -212,20 +212,20 @@ export default class Page extends Component {
           scale={scale}
         />
         {
-          renderTextLayer &&
-            <PageTextContent
-              key={`${page.pageIndex}@${scale}/${rotate}_text`}
-              onGetTextError={onGetTextError}
-              onGetTextSuccess={onGetTextSuccess}
+          renderAnnotations &&
+            <PageAnnotations
+              key={`${page.pageIndex}@${scale}/${rotate}_annotations`}
               page={page}
               rotate={rotate}
               scale={scale}
             />
         }
         {
-          renderAnnotations &&
-            <PageAnnotations
-              key={`${page.pageIndex}@${scale}/${rotate}_annotations`}
+          renderTextLayer &&
+            <PageTextContent
+              key={`${page.pageIndex}@${scale}/${rotate}_text`}
+              onGetTextError={onGetTextError}
+              onGetTextSuccess={onGetTextSuccess}
               page={page}
               rotate={rotate}
               scale={scale}


### PR DESCRIPTION
Because both layers have `position: absolute` and the same `z-index`, the [standard](https://www.w3.org/TR/CSS2/visuren.html#propdef-z-index) says that the last one is placed on top:

> Boxes with the same stack level in a stacking context are stacked back-to-front according to document tree order. 

Currently this has the consequence that the text in the text layer is unselectable, as the div is completely under the annotation layer. This change fixes that.