### PR TITLE
Page's div should contain page number in @data-page-number

### DIFF
--- a/src/Page.jsx
+++ b/src/Page.jsx
@@ -201,6 +201,7 @@ export default class Page extends Component {
         className={mergeClassNames('ReactPDF__Page', className)}
         ref={this.props.inputRef}
         style={{ position: 'relative' }}
+		{...{'data-page-number': page.pageIndex + 1}}
         {...this.eventProps}
       >
         <PageCanvas


### PR DESCRIPTION
Working with text selection is extremely hard without page numbers in DOM. `document.selection` contains only DOM node references in `anchorNode` and `focusNode` properties and getting text selection when selection covers multiple pages is quite a task without page numbers.

Take a look into [pdf.js implementation](https://mozilla.github.io/pdf.js/web/viewer.html)