### PR TITLE
Pin pdfjs-dist to 2.0.305

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5753,9 +5753,9 @@
       }
     },
     "pdfjs-dist": {
-      "version": "2.0.290",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.0.290.tgz",
-      "integrity": "sha1-lsWIVjWum+8rUdXX+zKDpaBpygA=",
+      "version": "2.0.305",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.0.305.tgz",
+      "integrity": "sha1-U7D5gFrhAdfvdC0CDQNXjul4GwY=",
       "requires": {
         "node-ensure": "0.0.0",
         "worker-loader": "1.1.0"

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "babel-runtime": "^6.26.0",
     "lodash.once": "^4.1.1",
     "merge-class-names": "^1.1.1",
-    "pdfjs-dist": "^2.0.290",
+    "pdfjs-dist": "2.0.305",
     "prop-types": "^15.6.0",
     "react": ">=15.5",
     "react-dom": ">=15.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3990,9 +3990,9 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-pdfjs-dist@^2.0.290:
-  version "2.0.290"
-  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-2.0.290.tgz#96c5885635ae9bef2b51d5d7fb3283a5a069ca00"
+pdfjs-dist@2.0.305:
+  version "2.0.305"
+  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-2.0.305.tgz#53b0f9805ae101d7ef742d020d03578ee9781b06"
   dependencies:
     node-ensure "^0.0.0"
     worker-loader "^1.1.0"


### PR DESCRIPTION
Fixes #149

As a side note, you have both `package-lock.json` and `yarn.lock`. This is confusing. Chose one of them and remove the other.