### PR TITLE
Add prop for custom text rendering

### DIFF
--- a/src/Page.jsx
+++ b/src/Page.jsx
@@ -84,7 +84,9 @@ export default class Page extends Component {
     if (this.props.onGetTextSuccess) {
       context.onGetTextSuccess = this.props.onGetTextSuccess;
     }
-
+    if (this.props.customTextRenderer) {
+      context.customTextRenderer = this.props.customTextRenderer;
+    }
     return context;
   }
 
@@ -349,6 +351,7 @@ Page.childContextTypes = {
   onGetTextSuccess: PropTypes.func,
   onRenderError: PropTypes.func,
   onRenderSuccess: PropTypes.func,
+  customTextRenderer: PropTypes.func,
   page: isPage,
   rotate: isRotate,
   scale: PropTypes.number,
@@ -380,5 +383,6 @@ Page.propTypes = {
   rotate: isRotate,
   scale: PropTypes.number,
   width: PropTypes.number,
+  customTextRenderer: PropTypes.func,
   ...eventsProps(),
 };

--- a/src/Page/TextLayer.jsx
+++ b/src/Page/TextLayer.jsx
@@ -1,13 +1,11 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Highlighter } from "react-highlight-words";
 
 import {
   callIfDefined,
   cancelRunningTask,
   errorOnDev,
   makeCancellable,
-  renderTextItem
 } from '../shared/utils';
 
 import { isPage, isRotate } from '../shared/propTypes';
@@ -153,7 +151,7 @@ export default class TextLayer extends Component {
   renderTextItem = (textItem, itemIndex) => {
 
     const { unrotatedViewport: viewport, defaultSideways } = this;
-    const { scale, page } = this.context;
+    const { scale } = this.context;
 
     const [xMin, yMin, /* xMax */, yMax] = viewport.viewBox;
 
@@ -166,22 +164,20 @@ export default class TextLayer extends Component {
 
     const fontSize = `${fontSizePx * scale}px`;
 
-    const divStyle = {
-      height: '1em',
-      fontFamily: fontName,
-      fontSize,
-      position: 'absolute',
-      top: `${(top + yMin) * scale}px`,
-      left: `${(left - xMin) * scale}px`,
-      transformOrigin: 'left bottom',
-      whiteSpace: 'pre',
-      pointerEvents: 'all',
-    }
-
     return (
       <div
         key={itemIndex}
-        style={divStyle}
+        style={{
+          height: '1em',
+          fontFamily: fontName,
+          fontSize,
+          position: 'absolute',
+          top: `${(top + yMin) * scale}px`,
+          left: `${(left - xMin) * scale}px`,
+          transformOrigin: 'left bottom',
+          whiteSpace: 'pre',
+          pointerEvents: 'all',
+        }}
         ref={(ref) => {
           if (!ref) {
             return;
@@ -198,7 +194,6 @@ export default class TextLayer extends Component {
       </div>
     );
   }
-
 
   renderTextItems() {
     const { textItems } = this.state;

--- a/src/__tests__/Page.jsx
+++ b/src/__tests__/Page.jsx
@@ -588,5 +588,35 @@ describe('Page', () => {
         expect(annotationLayer).toHaveLength(0);
       });
     });
+
+    it('sets customTextRenderer prop correctly', () => {
+      const { func: onLoadSuccess, promise: onLoadSuccessPromise } = makeAsyncCallback();
+
+      const customTextRenderer = (textItem, itemIndex) => {
+        return (
+          <mark> {textItem.str} </mark>
+        );
+      }
+
+      const component = shallow(
+        <Page
+          onLoadSuccess={onLoadSuccess}
+          pageIndex={0}
+          renderTextLayer={true}
+          customTextRenderer={customTextRenderer}
+        />,
+        {
+          context: {
+            pdf,
+          }
+        }
+      );
+
+      return onLoadSuccessPromise.then(() => {
+        component.update();
+        expect(component.instance().props.customTextRenderer).toBe(customTextRenderer);
+      });
+    });
+
   });
 });


### PR DESCRIPTION
Added optional prop `customTextRenderer` that allows user to pass in a function that will modify how text div is rendered within text layer. Possible use case includes the ability to highlight words.