### PR TITLE
Improve performance by preventing unnecessary renders.

### DIFF
--- a/src/Page/TextLayerItem.jsx
+++ b/src/Page/TextLayerItem.jsx
@@ -9,11 +9,11 @@ import { isPage, isRotate } from '../shared/propTypes';
 const BROKEN_FONT_ALARM_THRESHOLD = 0.1;
 
 export class TextLayerItemInternal extends PureComponent {
-  state = {
-    transform: null,
+  componentDidMount() {
+    this.alignTextItem();
   }
 
-  componentDidMount() {
+  componentDidUpdate() {
     this.alignTextItem();
   }
 
@@ -99,9 +99,7 @@ export class TextLayerItemInternal extends PureComponent {
 
     const ascent = fontData ? fontData.ascent : 1;
 
-    this.setState({
-      transform: `scaleX(${targetWidth / actualWidth}) translateY(${(1 - ascent) * 100}%)`,
-    });
+    element.style.transform = `scaleX(${targetWidth / actualWidth}) translateY(${(1 - ascent) * 100}%)`;
   }
 
   getElementWidth = (element) => {
@@ -112,7 +110,6 @@ export class TextLayerItemInternal extends PureComponent {
   render() {
     const { fontSize, top, left } = this;
     const { fontName, scale, str: text } = this.props;
-    const { transform } = this.state;
 
     return (
       <div
@@ -126,7 +123,6 @@ export class TextLayerItemInternal extends PureComponent {
           transformOrigin: 'left bottom',
           whiteSpace: 'pre',
           pointerEvents: 'all',
-          transform,
         }}
         ref={(ref) => { this.item = ref; }}
       >


### PR DESCRIPTION
fixes #213

The setState() call in TextLayerItem caused a significant number of extra renders in both TextLayerItem and PageCanvas. PageCanvas.render() was called an extra time for every TextLayerItem.

So, for example, if a document had 260 TextLayerItems, the page canvas was rendered 261 times (1 + number of TextLayerItems).

This was causing pretty a severe performance hit. In our testing, the update in this PR reduced total render time (Canvas + TextLayer) by ~95%, from over 7 seconds to under 400ms for a document with 1000 TextLayerItems.

There were a couple ways to go about this update. I removed transform from the state and added the this.alignTextItem() call to componentDidUpdate() because that guarantees that the new transform style is applied if React ever destroys & recreates the original DOM element.

If you prefer to apply the transform style in the render method and avoid unnecessary calls to this.alignTextItem(), another option is to store transform as a class property instead of in the component state, update that property & the element in alignTextItem() (but still with no setState()). That'll guarantee that the transform is applied on render(), but avoid the huge performance hit of causing re-renders by making a state update after the component mounts.