### PR TITLE
Fixes readme.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ class MyApp extends Component {
       <div>
         <Document
           file="somefile.pdf"
-          onLoadSuccess={this.onDocumentLoad}
+          onLoadSuccess={this.onDocumentLoad.bind(this)}
         >
           <Page pageNumber={pageNumber} />
         </Document>


### PR DESCRIPTION
onDocumentLoad() has `this` as `undefined` without binding the current object