### PR TITLE
Use PDFDocumentProxy API to access numPages

### DIFF
--- a/src/shared/propTypes.js
+++ b/src/shared/propTypes.js
@@ -74,7 +74,7 @@ export const isPageIndex = (props, propName, componentName) => {
       return new Error(`Expected \`${propName}\` to be greater or equal to 0.`);
     }
 
-    const { numPages } = pdf.pdfInfo;
+    const { numPages } = pdf;
 
     if (pageIndex + 1 > numPages) {
       return new Error(`Expected \`${propName}\` to be less or equal to ${numPages - 1}.`);
@@ -103,7 +103,7 @@ export const isPageNumber = (props, propName, componentName) => {
       return new Error(`Expected \`${propName}\` to be greater or equal to 1.`);
     }
 
-    const { numPages } = pdf.pdfInfo;
+    const { numPages } = pdf;
 
     if (pageNumber > numPages) {
       return new Error(`Expected \`${propName}\` to be less or equal to ${numPages}.`);


### PR DESCRIPTION
The [PDFDocumentProxy API](https://mozilla.github.io/pdf.js/api/draft/PDFDocumentProxy.html) allows accessing numPages directly. No longer uses the private pdfInfo API.

You mentioned this as resolved in #269, but I couldn't find fixed code for the propTypes.