### PR TITLE
Allow onTaskCreated for Document Component.

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Loads a document passed using `file` prop.
 |onPassword|Function called when a password-protected PDF is loaded. Defaults to a function that prompts the user for password.|`(callback) => callback('s3cr3t_p4ssw0rd')`|
 |onSourceError|Function called in case of an error while retrieving document source from `file` prop.|`(error) => alert('Error while retrieving document source! ' + error.message)`|
 |onSourceSuccess|Function called when document source is successfully retrieved from `file` prop.|`() => alert('Document source retrieved!')`|
+|onTaskCreated|Function called when a task to load a document has been created.|`(task) => if (queue.isFull) { task.cancel() } else { return queue.promise; }`|
 |options|An object in which additional parameters to be passed to PDF.js can be defined. For a full list of possible parameters, check [PDF.js documentation on DocumentInitParameters](https://mozilla.github.io/pdf.js/api/draft/global.html#DocumentInitParameters).|`{ cMapUrl: 'cmaps/', cMapPacked: true }`|
 |renderMode|Defines the rendering mode of the document. Can be `canvas`, `svg` or `none`. Defaults to `canvas`.|`"svg"`
 |rotate|Defines the rotation of the document in degrees. If provided, will change rotation globally, even for the pages which were given `rotate` prop of their own. 90 = rotated to the right, 180 = upside down, 270 = rotated to the left.|`90`|

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Loads a document passed using `file` prop.
 |onPassword|Function called when a password-protected PDF is loaded. Defaults to a function that prompts the user for password.|`(callback) => callback('s3cr3t_p4ssw0rd')`|
 |onSourceError|Function called in case of an error while retrieving document source from `file` prop.|`(error) => alert('Error while retrieving document source! ' + error.message)`|
 |onSourceSuccess|Function called when document source is successfully retrieved from `file` prop.|`() => alert('Document source retrieved!')`|
-|onTaskCreated|Function called when a task to load a document has been created.|`(task) => if (queue.isFull) { task.cancel() } else { return queue.promise; }`|
+|onTaskCreated|Function called when a task to load a document has been created.|`(task) => if (queue.isFull) { return task.cancel(); } else { return queue.promise; }`|
 |options|An object in which additional parameters to be passed to PDF.js can be defined. For a full list of possible parameters, check [PDF.js documentation on DocumentInitParameters](https://mozilla.github.io/pdf.js/api/draft/global.html#DocumentInitParameters).|`{ cMapUrl: 'cmaps/', cMapPacked: true }`|
 |renderMode|Defines the rendering mode of the document. Can be `canvas`, `svg` or `none`. Defaults to `canvas`.|`"svg"`
 |rotate|Defines the rotation of the document in degrees. If provided, will change rotation globally, even for the pages which were given `rotate` prop of their own. 90 = rotated to the right, 180 = upside down, 270 = rotated to the left.|`90`|

--- a/src/Document.jsx
+++ b/src/Document.jsx
@@ -101,7 +101,7 @@ export default class Document extends PureComponent {
       return { pdf: null };
     });
 
-    const { options, onLoadProgress, onPassword } = this.props;
+    const { options, onLoadProgress, onPassword, onTaskCreated } = this.props;
 
     try {
       const loadingTask = pdfjs.getDocument({ ...source, ...options }).promise;
@@ -111,6 +111,9 @@ export default class Document extends PureComponent {
       }
       const cancellable = makeCancellable(loadingTask);
       this.runningTask = cancellable;
+      if (onTaskCreated) {
+        onTaskCreated(cancellable);
+      }
       const pdf = await cancellable.promise;
       this.setState((prevState) => {
         if (prevState.pdf && prevState.pdf.fingerprint === pdf.fingerprint) {
@@ -392,6 +395,7 @@ Document.propTypes = {
   onItemClick: PropTypes.func,
   onLoadError: PropTypes.func,
   onLoadProgress: PropTypes.func,
+  onTaskCreated: PropTypes.func,
   onLoadSuccess: PropTypes.func,
   onPassword: PropTypes.func,
   onSourceError: PropTypes.func,

--- a/src/Document.jsx
+++ b/src/Document.jsx
@@ -101,7 +101,12 @@ export default class Document extends PureComponent {
       return { pdf: null };
     });
 
-    const { options, onLoadProgress, onPassword, onTaskCreated } = this.props;
+    const {
+      options,
+      onLoadProgress,
+      onPassword,
+      onTaskCreated,
+    } = this.props;
 
     try {
       const loadingTask = pdfjs.getDocument({ ...source, ...options }).promise;


### PR DESCRIPTION
Introduce onTaskCreated Document property.

onTaskCreated property allows for the client to have control over the task mechanism of the Document component. By exposing the task API the client has the ability to cancel in-flight tasks in the same manner that the Document component does. Without such an API there is no way that the client has a reasonable means of stopping an in-flight document from loading and taking over the Document view. This manifests itself in issue #357. PR provides test cases to ensure the correct implementation and that the Document component remains fully backwards compatible. 

Addresses:

1. #357 