### PR TITLE
Text Layer should be in the same spot as the canvas element

### DIFF
--- a/src/Page/TextLayer.jsx
+++ b/src/Page/TextLayer.jsx
@@ -122,12 +122,12 @@ export class TextLayerInternal extends PureComponent {
         className="react-pdf__Page__textContent"
         style={{
           position: 'absolute',
-          top: '50%',
-          left: '50%',
+          top: 0,
+          left: 0,
           width: `${viewport.width}px`,
           height: `${viewport.height}px`,
           color: 'transparent',
-          transform: `translate(-50%, -50%) rotate(${rotate}deg)`,
+          transform: `rotate(${rotate}deg)`,
           pointerEvents: 'none',
         }}
       >


### PR DESCRIPTION
`react-pdf__Page` is occasionally wider than the `react-pdf__Page__canvas` it contains. `react-pdf__Page__canvas` get put into top left corner of the `react-pdf__Page`, but `react-pdf__Page__textContent` get centered inside of `react-pdf__Page` resulting in misaligned text. This PR puts `react-pdf__Page__textContent` into top left corner of `react-pdf__Page` and aligning the text.