### PR TITLE
Add info on external cMaps support

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,19 @@ Now that you have cMaps in your build, pass required options to Document compone
 />
 ```
 
+Alternatively, you could use cMaps from external CDN:
+
+```js
+import { pdfjs } from 'react-pdf';
+
+<Document
+  options={{
+    cMapUrl: `//cdn.jsdelivr.net/npm/pdfjs-dist@${pdfjs.version}/cmaps/`
+    cMapPacked: true,
+  }}
+/>
+```
+
 ## User guide
 
 ### Document


### PR DESCRIPTION
Closes #420

@johejo can you confirm these instructions are working for you? I tried to make the code a little more foolproof.

Specifically, I'm talking about this line:

```js
cMapUrl: `//cdn.jsdelivr.net/npm/pdfjs-dist@${pdfjs.version}/cmaps/`
```