### PR TITLE
Follow up to fix from PR 369

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ import { Document } from 'react-pdf/dist/entry.parcel';
 
 #### Create React App
 
-Create React App uses Webpack under the hood, but instructions for Webpack will not work. [Standard instructions](#browserify-and-others) apply.
+Create React App uses Webpack under the hood, but instructions for Webpack will not work. [Standard instructions](#standard-browserify-and-others) apply.
 
 #### Standard (Browserify and others)
 


### PR DESCRIPTION
In https://github.com/wojtekmaj/react-pdf/pull/369 the title of the section was improved which is great.
However it broke the link for "Standard instructions", effectively doing more harm than good.