### PR TITLE
Patching bug where AnnotationLayer does not receive props from DocumentContext.Provider causing links to fail rendering

### DIFF
--- a/src/Page.jsx
+++ b/src/Page.jsx
@@ -320,7 +320,7 @@ export class PageInternal extends PureComponent {
      */
 
     return (
-      <AnnotationLayer key={`${this.pageKey}_annotations`} />
+      <AnnotationLayer key={`${this.pageKey}_annotations`} {...this.props} />
     );
   }
 


### PR DESCRIPTION
Document uses DocumentContext.Provider på push linkService down to Page
and AnnotationLayer. This works fine with the webpack build and with `npm start` using parcel.

How ever, for some strange reason, the build files from parcel build does _not_
work the same way. This can be seen easily with serving the dist-folder
with a webserver. The link in the renderd pdf does not work.
And this is because there is an exception now inside pdf.js where
the annotation rendering hits a undefined when trying to use read `externalLinkTarget`
from `linkService`. It turns out that in src/Page/AnnotationLayer.js:173
documentContext does not inherit the props of Page resulting in the
rendered instance of AnnotationLayer now has linkService === undefined.