### PR TITLE
The enrty points have side effects

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "dist/umd/entry.js",
   "module": "dist/esm/entry.js",
   "source": "src/entry.js",
-  "sideEffects": false,
   "scripts": {
     "build": "yarn build-js-all && yarn copy-styles",
     "build-js-all": "yarn build-js-esm && yarn build-js-umd",

--- a/src/Message.jsx
+++ b/src/Message.jsx
@@ -7,6 +7,7 @@ export default function Message({ children, type }) {
       {children}
     </div>
   );
+}
 
 Message.propTypes = {
   children: PropTypes.node,


### PR DESCRIPTION
Webpack `mode: production` builds cause pdfjs fall back to the "fake
worker" with `sideEffects: false` in react-pdf's package.json.

I believe the optimisation related to `sideEffects: false` is preventing these lines from executing when using the Webpack entrypoint:
https://github.com/wojtekmaj/react-pdf/blob/adb00b8a89c9ce2a27b554f348258b5a0a2c9e69/src/entry.webpack.js#L14-L16

Relevant reading:
https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free
https://stackoverflow.com/a/49203452/2410292