### PR TITLE
Upgrade pdfjs-dist to 2.4.456

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,7 @@
     }],
     "jsx-a11y/label-has-associated-control": ["error", { "required": { "some": ["id", "nesting"] }}],
     "no-param-reassign": ["error", { "props": true, "ignorePropertyModificationsFor": ["canvas", "element", "svg"] }],
-    "no-underscore-dangle": ["error", { "allow": ["_pdfInfo", "_pageInfo"] }],
+    "no-underscore-dangle": ["error", { "allow": ["_pdfInfo", "_pageInfo", "_pageIndex"] }],
     "react/jsx-props-no-spreading": "off",
     "react/jsx-sort-props": ["error", {
       "reservedFirst": ["key"]

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "make-cancellable-promise": "^1.0.0",
     "make-event-props": "^1.1.0",
     "merge-class-names": "^1.1.1",
-    "pdfjs-dist": "2.2.228",
+    "pdfjs-dist": "2.4.456",
     "prop-types": "^15.6.2"
   },
   "devDependencies": {

--- a/src/Document.jsx
+++ b/src/Document.jsx
@@ -14,6 +14,7 @@ import Message from './Message';
 
 import LinkService from './LinkService';
 import PasswordResponses from './PasswordResponses';
+import eventBus from './eventBus';
 
 import {
   callIfDefined,
@@ -61,7 +62,7 @@ export default class Document extends PureComponent {
     },
   };
 
-  linkService = new LinkService();
+  linkService = new LinkService({ eventBus });
 
   componentDidMount() {
     this.loadDocument();

--- a/src/Page.spec.jsx
+++ b/src/Page.spec.jsx
@@ -34,24 +34,24 @@ describe('Page', () => {
     pdf = await pdfjs.getDocument({ data: pdfFile.arrayBuffer }).promise;
 
     const page = await pdf.getPage(1);
-    desiredLoadedPage.pageIndex = page.pageIndex;
+    desiredLoadedPage._pageIndex = page._pageIndex;
     desiredLoadedPage._pageInfo = page._pageInfo;
 
     const page2 = await pdf.getPage(2);
-    desiredLoadedPage2.pageIndex = page2.pageIndex;
+    desiredLoadedPage2._pageIndex = page2._pageIndex;
     desiredLoadedPage2._pageInfo = page2._pageInfo;
 
     pdf2 = await pdfjs.getDocument({ data: pdfFile2.arrayBuffer }).promise;
 
     const page3 = await pdf2.getPage(1);
-    desiredLoadedPage3.pageIndex = page3.pageIndex;
+    desiredLoadedPage3._pageIndex = page3._pageIndex;
     desiredLoadedPage3._pageInfo = page3._pageInfo;
 
     registerPageArguments.push(
-      page.pageIndex,
+      page._pageIndex,
       undefined, // Page reference is not defined in Enzyme
     );
-    unregisterPageArguments = page.pageIndex;
+    unregisterPageArguments = page._pageIndex;
   });
 
   describe('loading', () => {

--- a/src/Page/AnnotationLayer.spec.jsx
+++ b/src/Page/AnnotationLayer.spec.jsx
@@ -11,13 +11,14 @@ import failingPage from '../../__mocks__/_failing_page';
 import {
   loadPDF, makeAsyncCallback, muteConsole, restoreConsole,
 } from '../../test-utils';
+import eventBus from '../eventBus';
 
 const pdfFile = loadPDF('./__mocks__/_pdf.pdf');
 
 /* eslint-disable comma-dangle */
 
 describe('AnnotationLayer', () => {
-  const linkService = new LinkService();
+  const linkService = new LinkService({ eventBus });
 
   // Loaded page
   let page;

--- a/src/entry.jest.js
+++ b/src/entry.jest.js
@@ -1,9 +1,9 @@
-import pdfjs from 'pdfjs-dist';
+import pdfjs from 'pdfjs-dist/es5/build/pdf';
 import Document from './Document';
 import Outline from './Outline';
 import Page from './Page';
 
-import './pdf.worker.entry';
+import './pdf.worker.entry.jest';
 
 export {
   pdfjs,

--- a/src/eventBus.js
+++ b/src/eventBus.js
@@ -1,0 +1,3 @@
+import { EventBus } from 'pdfjs-dist/lib/web/ui_utils';
+
+export default new EventBus();

--- a/src/pdf.worker.entry.jest.js
+++ b/src/pdf.worker.entry.jest.js
@@ -1,0 +1,13 @@
+/**
+ * PDF.js Worker entry file.
+ *
+ * This file is identical to Mozilla's pdf.worker.entry.js, with one exception being placed inside
+ * this bundle, not theirs. This file can be safely removed and replaced with Mozilla's after the
+ * issue mentioned below has been resolved on Parcel's side.
+ * See: https://github.com/parcel-bundler/parcel/issues/670
+ */
+
+(typeof window !== 'undefined'
+  ? window
+  : {}
+).pdfjsWorker = require('pdfjs-dist/es5/build/pdf.worker.js');

--- a/yarn.lock
+++ b/yarn.lock
@@ -4318,7 +4318,7 @@ loader-runner@^2.4.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
-loader-utils@^1.0.0, loader-utils@^1.2.3:
+loader-utils@^1.2.3:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
   integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
@@ -4664,11 +4664,6 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
-
-node-ensure@^0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/node-ensure/-/node-ensure-0.0.0.tgz#ecae764150de99861ec5c810fd5d096b183932a7"
-  integrity sha1-7K52QVDemYYexcgQ/V0Jaxg5Mqc=
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -5082,13 +5077,10 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-pdfjs-dist@2.2.228:
-  version "2.2.228"
-  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-2.2.228.tgz#777b068a0a16c96418433303807c183058b47aaa"
-  integrity sha512-W5LhYPMS2UKX0ELIa4u+CFCMoox5qQNQElt0bAK2mwz1V8jZL0rvLao+0tBujce84PK6PvWG36Nwr7agCCWFGQ==
-  dependencies:
-    node-ensure "^0.0.0"
-    worker-loader "^2.0.0"
+pdfjs-dist@2.4.456:
+  version "2.4.456"
+  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-2.4.456.tgz#0eaad2906cda866bbb393e79a0e5b4e68bd75520"
+  integrity sha512-yckJEHq3F48hcp6wStEpbN9McOj328Ib09UrBlGAKxvN2k+qYPN5iq6TH6jD1C0pso7zTep+g/CKsYgdrQd5QA==
 
 performance-now@^2.1.0:
   version "2.1.0"
@@ -5718,14 +5710,6 @@ scheduler@^0.19.0:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-
-schema-utils@^0.4.0:
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
-  integrity sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==
-  dependencies:
-    ajv "^6.1.0"
-    ajv-keywords "^3.1.0"
 
 schema-utils@^1.0.0:
   version "1.0.0"
@@ -6682,14 +6666,6 @@ worker-farm@^1.7.0:
   integrity sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==
   dependencies:
     errno "~0.1.7"
-
-worker-loader@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/worker-loader/-/worker-loader-2.0.0.tgz#45fda3ef76aca815771a89107399ee4119b430ac"
-  integrity sha512-tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==
-  dependencies:
-    loader-utils "^1.0.0"
-    schema-utils "^0.4.0"
 
 wrap-ansi@^6.2.0:
   version "6.2.0"


### PR DESCRIPTION
https://github.com/wojtekmaj/react-pdf/issues/280

Due to issues caused with cross site loading of the pdf service worker, it is needed for us to upgrade the version of the `pdfjs-dist` package.    

There was one deprecation that was raised in this upgrade that is addressed regarding the EventBus.  The default global event bus was deprecated, so you have to manually manage it.  