### PR TITLE
fix text selection flickering and chrome performance

### DIFF
--- a/src/Page/EndOfContent.jsx
+++ b/src/Page/EndOfContent.jsx
@@ -1,0 +1,39 @@
+import React, { forwardRef, PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { isRef } from '../shared/propTypes';
+
+class EndOfContentInternal extends PureComponent {
+  render() {
+    const { forwardedRef, top } = this.props;
+    return (
+      <div
+        ref={forwardedRef}
+        style={{
+          display: 'block',
+          position: 'absolute',
+          left: 0,
+          top,
+          right: 0,
+          bottom: 0,
+          zIndex: -1,
+          cursor: 'default',
+          userSelect: 'none',
+          WebkitUserSelect: 'none',
+          MozUserSelect: 'none',
+          MsUserSelect: 'none',
+        }}
+      />
+    );
+  }
+}
+
+EndOfContentInternal.propTypes = {
+  forwardedRef: isRef,
+  top: PropTypes.string,
+};
+
+function EndOfContent(props, ref) {
+  return <EndOfContentInternal {...props} forwardedRef={ref} />;
+}
+
+export default forwardRef(EndOfContent);

--- a/src/Page/TextLayer.spec.jsx
+++ b/src/Page/TextLayer.spec.jsx
@@ -113,7 +113,7 @@ describe('TextLayer', () => {
       expect.assertions(1);
       return onGetTextSuccessPromise.then(() => {
         component.update();
-        const textItems = component.children();
+        const textItems = component.children().children('TextLayerItem');
 
         expect(textItems).toHaveLength(desiredTextItems.length);
       });

--- a/src/Page/TextLayerItem.jsx
+++ b/src/Page/TextLayerItem.jsx
@@ -81,7 +81,7 @@ export class TextLayerItemInternal extends PureComponent {
 
     element.style.transform = '';
 
-    const { fontName, scale, width } = this.props;
+    const { fontName } = this.props;
 
     element.style.fontFamily = `${fontName}, sans-serif`;
 
@@ -89,25 +89,7 @@ export class TextLayerItemInternal extends PureComponent {
 
     const fallbackFontName = fontData ? fontData.fallbackName : 'sans-serif';
     element.style.fontFamily = `${fontName}, ${fallbackFontName}`;
-
-    const targetWidth = width * scale;
-    const actualWidth = this.getElementWidth(element);
-
-    let transform = `scaleX(${targetWidth / actualWidth})`;
-
-    const ascent = fontData ? fontData.ascent : 0;
-    if (ascent) {
-      transform += ` translateY(${(1 - ascent) * 100}%)`;
-    }
-
-    element.style.transform = transform;
-    element.style.WebkitTransform = transform;
   }
-
-  getElementWidth = (element) => {
-    const { sideways } = this;
-    return element.getBoundingClientRect()[sideways ? 'height' : 'width'];
-  };
 
   render() {
     const { fontSize, top, left } = this;
@@ -123,7 +105,7 @@ export class TextLayerItemInternal extends PureComponent {
           position: 'absolute',
           top: `${top * scale}px`,
           left: `${left * scale}px`,
-          transformOrigin: 'left bottom',
+          transformOrigin: '0 0',
           whiteSpace: 'pre',
           pointerEvents: 'all',
         }}
@@ -147,7 +129,6 @@ TextLayerItemInternal.propTypes = {
   scale: PropTypes.number,
   str: PropTypes.string.isRequired,
   transform: PropTypes.arrayOf(PropTypes.number).isRequired,
-  width: PropTypes.number.isRequired,
 };
 
 export default function TextLayerItem(props) {

--- a/src/shared/propTypes.js
+++ b/src/shared/propTypes.js
@@ -125,6 +125,13 @@ export const isPdf = PropTypes.oneOfType([
   PropTypes.bool,
 ]);
 
+export const isRef = PropTypes.oneOfType([
+  PropTypes.func,
+  PropTypes.shape({
+    current: PropTypes.any,
+  }),
+]);
+
 export const isRenderMode = PropTypes.oneOf(['canvas', 'none', 'svg']);
 
 export const isRotate = PropTypes.oneOf([0, 90, 180, 270]);


### PR DESCRIPTION
I use https://github.com/mozilla/pdf.js/blob/50bc4a18e8c564753365d927d5ec6a6d2cce3072/web/text_layer_builder.js for inspiration to solve problem when you select text and cursor move between text layer items and selection invert to top of page. 
Related issues: 
https://github.com/wojtekmaj/react-pdf/issues/101
https://github.com/wojtekmaj/react-pdf/issues/602
https://github.com/wojtekmaj/react-pdf/issues/599