### PR TITLE
Update pdfjs-dist to 2.6.347

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "make-event-props": "^1.1.0",
     "merge-class-names": "^1.1.1",
     "merge-refs": "^1.0.0",
-    "pdfjs-dist": "2.5.207",
+    "pdfjs-dist": "2.6.347",
     "prop-types": "^15.6.2",
     "worker-loader": "^3.0.0"
   },

--- a/test/yarn.lock
+++ b/test/yarn.lock
@@ -8021,10 +8021,10 @@ fsevents@^2.1.2:
   languageName: node
   linkType: hard
 
-"pdfjs-dist@npm:2.5.207":
-  version: 2.5.207
-  resolution: "pdfjs-dist@npm:2.5.207"
-  checksum: b1a1536d46507493316cdb1f90e103f95a1538353c592c5b31a70bff39d4a10ee731541705d95aa36b7293ffca8af2203af2a86af1761fae75b65b1be196c147
+"pdfjs-dist@npm:2.6.347":
+  version: 2.6.347
+  resolution: "pdfjs-dist@npm:2.6.347"
+  checksum: 64007e9fce35be3d9e8a2d106bdcd350cd71df4f4fe99a94adbdb4ee662ce1e84abfe0feff38d6cfa94fa79a291cfe96f1efd874e8417c52d7ab753d2046bf26
   languageName: node
   linkType: hard
 
@@ -8503,7 +8503,7 @@ fsevents@^2.1.2:
     make-event-props: ^1.1.0
     merge-class-names: ^1.1.1
     merge-refs: ^1.0.0
-    pdfjs-dist: 2.5.207
+    pdfjs-dist: 2.6.347
     prop-types: ^15.6.2
     react: ^17.0.0
     react-dom: ^17.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -6709,10 +6709,10 @@ fsevents@^2.1.2:
   languageName: node
   linkType: hard
 
-"pdfjs-dist@npm:2.5.207":
-  version: 2.5.207
-  resolution: "pdfjs-dist@npm:2.5.207"
-  checksum: b1a1536d46507493316cdb1f90e103f95a1538353c592c5b31a70bff39d4a10ee731541705d95aa36b7293ffca8af2203af2a86af1761fae75b65b1be196c147
+"pdfjs-dist@npm:2.6.347":
+  version: 2.6.347
+  resolution: "pdfjs-dist@npm:2.6.347"
+  checksum: 64007e9fce35be3d9e8a2d106bdcd350cd71df4f4fe99a94adbdb4ee662ce1e84abfe0feff38d6cfa94fa79a291cfe96f1efd874e8417c52d7ab753d2046bf26
   languageName: node
   linkType: hard
 
@@ -6985,7 +6985,7 @@ fsevents@^2.1.2:
     make-event-props: ^1.1.0
     merge-class-names: ^1.1.1
     merge-refs: ^1.0.0
-    pdfjs-dist: 2.5.207
+    pdfjs-dist: 2.6.347
     prop-types: ^15.6.2
     react: ^17.0.0
     react-dom: ^17.0.0


### PR DESCRIPTION
Hey guys, I don't know what you think about keeping the pdfjs version up-to-date, and I honestly can't overlook if this could break anything in react-pdf. However I need to run react-pdf with a newer pdfjs version, and I would prefer not to use a fork...

If there is anything I can further do, to make sure this could make it into upstream I'd be happy to help.