### PR TITLE
Destroy previous worker when file changes

### DIFF
--- a/src/Document.jsx
+++ b/src/Document.jsx
@@ -111,8 +111,11 @@ export default class Document extends PureComponent {
     const { options, onLoadProgress, onPassword } = this.props;
 
     try {
-      // If another loading is in progress, let's cancel it
+      // If another rendering is in progress, let's cancel it
       cancelRunningTask(this.runningTask);
+
+      // If another loading is in progress, let's destroy it
+      if (this.loadingTask) this.loadingTask.destroy();
 
       this.loadingTask = pdfjs.getDocument({ ...source, ...options });
       this.loadingTask.onPassword = onPassword;


### PR DESCRIPTION
Closes #288
Closes #305

`react-pdf` creates new worker for each `file` update and doesn't destroy previous one. I fix it

memory usage before update:
<img width="488" alt="Снимок экрана 2021-03-31 в 19 42 02" src="https://user-images.githubusercontent.com/6726016/113180437-66d65800-9259-11eb-95ee-9bf08c782cec.png">

memory usage after: 
<img width="536" alt="Снимок экрана 2021-03-31 в 19 43 12" src="https://user-images.githubusercontent.com/6726016/113180457-6dfd6600-9259-11eb-9aa1-d285394a9d7b.png">

