### PR TITLE
Use public API for rendering cancellation

### DIFF
--- a/src/Page/PageCanvas.jsx
+++ b/src/Page/PageCanvas.jsx
@@ -42,11 +42,10 @@ export class PageCanvasInternal extends PureComponent {
   }
 
   cancelRenderingTask() {
-    /* eslint-disable no-underscore-dangle */
-    if (this.renderer && this.renderer._internalRenderTask.running) {
-      this.renderer._internalRenderTask.cancel();
+    if (this.renderer) {
+      this.renderer.cancel();
+      this.renderer = null;
     }
-    /* eslint-enable no-underscore-dangle */
   }
 
   /**


### PR DESCRIPTION
`page.render` returns `RenderTask` instance https://github.com/mozilla/pdf.js/blob/master/src/display/api.js#L1216-L1220
that has `cancel` method https://github.com/mozilla/pdf.js/blob/master/src/display/api.js#L2929-L2935

Do you have any secret reason to use private API for cancelation? If not, this PR uses public 😌

Related to #736
Related to #374 