### PR TITLE
fix: use one pdf worker for all documents and for all rerenders

### DIFF
--- a/src/Singleton.js
+++ b/src/Singleton.js
@@ -1,0 +1,29 @@
+class Singleton {
+  constructor(create, destroy) {
+    this.create = create;
+    this.destroy = destroy;
+
+    this.usageCount = 0;
+  }
+
+  acquire() {
+    if (!this.usageCount) {
+      this.instance = this.create();
+    }
+
+    this.usageCount += 1;
+
+    return this.instance;
+  }
+
+  release() {
+    this.usageCount -= 1;
+
+    if (this.usageCount <= 0) {
+      this.destroy(this.instance);
+      this.usageCount = 0;
+    }
+  }
+}
+
+export default Singleton;

--- a/src/Singleton.spec.js
+++ b/src/Singleton.spec.js
@@ -1,0 +1,35 @@
+import Singleton from './Singleton';
+
+describe('Singleton', () => {
+  it('should create instance only on first acquire call', () => {
+    const create = jest.fn();
+    const singleton = new Singleton(create, () => {});
+
+    singleton.acquire();
+    singleton.acquire();
+
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it('should destroy instance when nobody uses it', () => {
+    const destroy = jest.fn();
+    const singleton = new Singleton(() => {}, destroy);
+
+    singleton.acquire();
+    singleton.acquire();
+    singleton.release();
+    singleton.release();
+
+    expect(destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns one instance for all acquire calls', () => {
+    const instance = {};
+    const singleton = new Singleton(() => instance, () => {});
+
+    const first = singleton.acquire();
+    const second = singleton.acquire();
+
+    expect(first).toEqual(second);
+  });
+});


### PR DESCRIPTION
`react-pdf` v5.3 with `file-loader` creates new worker for all file's change and for all `Document` instances, so I create a singleton that reuse worker while rerenders and in different documents

