### PR TITLE
make webpack entry support es5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-pdf",
+  "name": "sd-react-pdf",
   "version": "5.3.0",
   "description": "Display PDFs in your React app as easily as if they were images.",
   "main": "dist/umd/entry.js",

--- a/src/entry.webpack.js
+++ b/src/entry.webpack.js
@@ -1,6 +1,6 @@
-import * as pdfjs from 'pdfjs-dist';
+import * as pdfjs from 'pdfjs-dist/es5/build/pdf.js';
 // eslint-disable-next-line
-import pdfjsWorker from 'file-loader!pdfjs-dist/build/pdf.worker';
+import pdfjsWorker from 'file-loader!pdfjs-dist/es5/build/pdf.worker';
 
 import Document from './Document';
 import Outline from './Outline';


### PR DESCRIPTION
code of react-pdf has supports es5, but the dependency `pdfjs-dist` doesn't support es5 simplely by import, we should import the files under `pdfjs-dist/es5`