### PR TITLE
Fix conflicting values for 'process.env.NODE_ENV'

### DIFF
--- a/sample/webpack5/webpack.config.js
+++ b/sample/webpack5/webpack.config.js
@@ -47,7 +47,7 @@ module.exports = {
   plugins: [
     new webpack.DefinePlugin({
       'process.env': {
-        NODE_ENV: JSON.stringify(isProduction ? 'production' : 'development'),
+        NODE_ENV: JSON.stringify(process.env.NODE_ENV),
       },
     }),
     new HtmlWebpackPlugin({

--- a/sample/webpack5/webpack.config.js
+++ b/sample/webpack5/webpack.config.js
@@ -47,7 +47,7 @@ module.exports = {
   plugins: [
     new webpack.DefinePlugin({
       'process.env': {
-        NODE_ENV: JSON.stringify('production'),
+        NODE_ENV: JSON.stringify(isProduction ? 'production' : 'development'),
       },
     }),
     new HtmlWebpackPlugin({


### PR DESCRIPTION
I met the following error while trying out the sample for webpack5

```
WARNING in DefinePlugin
Conflicting values for 'process.env.NODE_ENV'

1 WARNING in child compilations (Use 'stats.children: true' resp. '--stats-children' for more details)

1 warning has detailed information that is not shown.
Use 'stats.errorDetails: true' resp. '--stats-error-details' to show it.

webpack 5.52.0 compiled with 2 warnings in 9208 ms
```

So this PR is for changing the variable that caused the warning. 