### PR TITLE
Clean cancel

### DIFF
--- a/src/Document.jsx
+++ b/src/Document.jsx
@@ -85,8 +85,13 @@ export default class Document extends PureComponent {
     // If rendering is in progress, let's cancel it
     cancelRunningTask(this.runningTask);
 
-    // If loading is in progress, let's destroy it
+    // If pdfjs loading is in progress, let's destroy it
     if (this.loadingTask) this.loadingTask.destroy();
+
+    // If FileReader loading is in progress, let's abort it
+    if (this.loadFromFileTask) {
+      this.loadFromFileTask.abort();
+    }
   }
 
   loadDocument = () => {
@@ -263,7 +268,14 @@ export default class Document extends PureComponent {
     if (isBrowser) {
       // File is a Blob
       if (isBlob(file) || isFile(file)) {
-        loadFromFile(file).then((data) => {
+        // abort previous FileReader, if there is one
+        if (this.loadFromFileTask) {
+          this.loadFromFileTask.abort();
+        }
+
+        this.loadFromFileTask = loadFromFile(file);
+        this.loadFromFileTask.promise.then((data) => {
+          this.loadFromFileTask = null;
           resolve({ data });
         });
         return;

--- a/src/Document.jsx
+++ b/src/Document.jsx
@@ -89,7 +89,7 @@ export default class Document extends PureComponent {
     if (this.loadingTask) this.loadingTask.destroy();
 
     // If FileReader loading is in progress, let's abort it
-    if (this.loadFromFileTask) this.loadFromFileTask.abort();
+    if (this.loadFromFileTask) this.loadFromFileTask.cancel();
   }
 
   loadDocument = () => {
@@ -268,7 +268,7 @@ export default class Document extends PureComponent {
       if (isBlob(file) || isFile(file)) {
         // abort previous FileReader, if there is one
         if (this.loadFromFileTask) {
-          this.loadFromFileTask.abort();
+          this.loadFromFileTask.cancel();
         }
 
         this.loadFromFileTask = loadFromFile(file);

--- a/src/Document.jsx
+++ b/src/Document.jsx
@@ -89,9 +89,7 @@ export default class Document extends PureComponent {
     if (this.loadingTask) this.loadingTask.destroy();
 
     // If FileReader loading is in progress, let's abort it
-    if (this.loadFromFileTask) {
-      this.loadFromFileTask.abort();
-    }
+    if (this.loadFromFileTask) this.loadFromFileTask.abort();
   }
 
   loadDocument = () => {

--- a/src/Page.jsx
+++ b/src/Page.jsx
@@ -246,6 +246,13 @@ export class PageInternal extends PureComponent {
       return { page: null };
     });
 
+    // eslint-disable-next-line no-underscore-dangle
+    if (pdf && pdf._transport && pdf._transport.destroyed) {
+      this.setState({ page: false });
+      this.onLoadError('Attempted to load a page, but the document was destroyed');
+      return;
+    }
+
     const cancellable = makeCancellable(pdf.getPage(pageNumber));
     this.runningTask = cancellable;
 

--- a/src/Page.jsx
+++ b/src/Page.jsx
@@ -249,7 +249,7 @@ export class PageInternal extends PureComponent {
     // eslint-disable-next-line no-underscore-dangle
     if (pdf && pdf._transport && pdf._transport.destroyed) {
       this.setState({ page: false });
-      this.onLoadError('Attempted to load a page, but the document was destroyed');
+      this.onLoadError(new Error('Attempted to load a page, but the document was destroyed'));
       return;
     }
 

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -141,9 +141,8 @@ export function isCancelException(error) {
 }
 
 export function loadFromFile(file) {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-
+  const reader = new FileReader();
+  const promise = new Promise((resolve, reject) => {
     reader.onload = () => resolve(new Uint8Array(reader.result));
     reader.onerror = (event) => {
       switch (event.target.error.code) {
@@ -163,4 +162,11 @@ export function loadFromFile(file) {
 
     return null;
   });
+
+  return {
+    promise,
+    abort: () => {
+      reader.abort();
+    },
+  };
 }

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -165,7 +165,7 @@ export function loadFromFile(file) {
 
   return {
     promise,
-    abort: () => {
+    cancel: () => {
       reader.abort();
     },
   };

--- a/test/LoadingOptions.jsx
+++ b/test/LoadingOptions.jsx
@@ -8,6 +8,8 @@ import { isFile } from './shared/propTypes';
 export default function LoadingOptions({
   file,
   setFile,
+  useExternPage,
+  setUseExternPage,
   setRender,
 }) {
   function onFileChange(event) {
@@ -122,6 +124,18 @@ export default function LoadingOptions({
           Unload file
         </button>
       </div>
+
+      <div>
+        <input
+          id="pageOutsideOfDocument"
+          type="checkbox"
+          checked={useExternPage}
+          onChange={(event) => { setUseExternPage(event.target.checked); }}
+        />
+        <label htmlFor="pageOutsideOfDocument">
+          Page outside of Document
+        </label>
+      </div>
     </fieldset>
   );
 }
@@ -130,4 +144,6 @@ LoadingOptions.propTypes = {
   file: isFile,
   setFile: PropTypes.func.isRequired,
   setRender: PropTypes.func.isRequired,
+  setUseExternPage: PropTypes.func.isRequired,
+  useExternPage: PropTypes.bool.isRequired,
 };

--- a/test/Test.jsx
+++ b/test/Test.jsx
@@ -149,7 +149,7 @@ export default function Test() {
             if (isBrowser) {
               // File is a Blob
               if (isBlob(file) || isFile(file)) {
-                return { data: await loadFromFile(file) };
+                return { data: await loadFromFile(file).promise };
               }
             }
             return file;


### PR DESCRIPTION
I have a suggestion about cleaner error handling, if you like.
_(Note that this is my first pull request ever, sorry if I do something wrong)_

1. Cancel loading a Page if the parent Document was unmounted.  
  I know that react-pdf is not meant to be used like this anyway, but it seems it would be an easy fix.
  (commit "cancel Page load if Document destroyed")
2. Cancel loading a file from the filesystem (FileReader) if the Document is unmounted.
  (commit "abort file load on document reload/unmount")
3. Another test component, to test Page "independant" of Document
  (commit "add test for Page outside Document")

### Testing:

#### 1. "cancel Page load if Document destroyed"

- load any PDF file
- check the new checkbox "Page outside of Document"
- click "remove Document" (at the top, in my new test component)
- click "remove Page"    (or alternatively: click "next")
- click "re-mount Page"

BEFORE:
TypeError: "this.messageHandler is null"

NOW:
callback .onLoadError("Attempted to load a page, but the document was destroyed")

#### 2. "abort file load on document reload/unmount"

- check the new checkbox "Page outside of Document"
- check the new checkbox "unmount Document on file load"
- load a PDF from a file

BEFORE:
"Warning: Can't perform a React state update on an unmounted component"

NOW:
no error in console (file load was aborted, setState wasn't called)