### PR TITLE
added type: module to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/umd/entry.js",
   "module": "dist/esm/entry.js",
   "source": "src/entry.js",
+  "type": "module",
   "scripts": {
     "build": "yarn build-js-all && yarn copy-styles",
     "build-js-all": "yarn build-js-esm && yarn build-js-umd",


### PR DESCRIPTION
Fixes `SyntaxError: Cannot use import statement outside a module` with Next.js and using worker:
`import { Document, Page } from 'react-pdf/dist/esm/entry.webpack';`

https://github.com/vercel/next.js/issues/30441
