### PR TITLE
Use workerPort instead of workerSrc in Parcel 2 specific entry

### DIFF
--- a/src/entry.parcel2.js
+++ b/src/entry.parcel2.js
@@ -8,14 +8,11 @@ import { displayWorkerWarning } from './shared/utils';
 
 displayWorkerWarning();
 
-pdfjs.GlobalWorkerOptions.workerSrc = new URL(
-  'npm:pdfjs-dist/legacy/build/pdf.worker',
-  import.meta.url,
-);
-
-pdfjs.GlobalWorkerOptions.workerPort = new Worker(
-  new URL('./pdf.worker.entry.js', import.meta.url),
-  { type: 'module' },
-);
+if (typeof window !== 'undefined' && 'Worker' in window) {
+  pdfjs.GlobalWorkerOptions.workerPort = new Worker(
+    new URL('./pdf.worker.entry.js', import.meta.url), 
+    { type: 'module' },
+  );
+}
 
 export { pdfjs, Document, Outline, Page };

--- a/src/entry.parcel2.js
+++ b/src/entry.parcel2.js
@@ -13,4 +13,9 @@ pdfjs.GlobalWorkerOptions.workerSrc = new URL(
   import.meta.url,
 );
 
+pdfjs.GlobalWorkerOptions.workerPort = new Worker(
+  new URL('./pdf.worker.entry.js', import.meta.url),
+  { type: 'module' },
+);
+
 export { pdfjs, Document, Outline, Page };


### PR DESCRIPTION
Hi,
I noticed that React PDF fails to load a document when built using Parcel 2. It works fine in development (using `parcel` or `parcel serve`) but fails to work in a full build (`parcel build`).

I needed to instantiate the `GlobalWorkerOptions.workerPort` as per this commit:
https://github.com/wojtekmaj/react-pdf/pull/917

I created a simple example project here:
https://github.com/jamesjessian/react-pdf-parcel-2-test

```
git clone https://github.com/jamesjessian/react-pdf-parcel-2-test
cd react-pdf-parcel-2-test
npm install
npm run clean:build:serve
```