### PR TITLE
Batched the getBoundingClientRect and style changes and added an IntersectionObserver

### DIFF
--- a/src/Page.jsx
+++ b/src/Page.jsx
@@ -81,6 +81,7 @@ export class PageInternal extends PureComponent {
       onGetAnnotationsSuccess,
       onGetTextError,
       onGetTextSuccess,
+      useObserverAlignText,
       onRenderAnnotationLayerError,
       onRenderAnnotationLayerSuccess,
       onRenderError,
@@ -96,6 +97,7 @@ export class PageInternal extends PureComponent {
       onGetAnnotationsSuccess,
       onGetTextError,
       onGetTextSuccess,
+      useObserverAlignText,
       onRenderAnnotationLayerError,
       onRenderAnnotationLayerSuccess,
       onRenderError,
@@ -397,6 +399,7 @@ PageInternal.propTypes = {
   rotate: isRotate,
   scale: PropTypes.number,
   unregisterPage: PropTypes.func,
+  useObserverAlignText : PropTypes.bool,
   width: PropTypes.number,
 };
 

--- a/src/Page/TextLayer.jsx
+++ b/src/Page/TextLayer.jsx
@@ -66,7 +66,7 @@ export class TextLayerInternal extends PureComponent {
     for (const entry of entries) {
       width = entry.boundingClientRect[sideways ? 'height' : 'width'];
       if(width > 0){
-        this.refTextItems.current[entry.target.i].alignTextItem(width);
+        this.refTextItems.current[entry.target.i].updatedWidth(width).alignTextItem()
       }
     }
     this.observer.disconnect();
@@ -78,9 +78,11 @@ export class TextLayerInternal extends PureComponent {
 
     if(useObserverAlignText){
       for(let i = 0; i < this.refTextItems.current.length; i++){
-        let entry = this.refTextItems.current[i].item;
-        entry.i = i;
-        this.observer.observe(entry);
+        let entry = this.refTextItems.current[i]
+        if(entry.props.str.length > 0){
+          entry.item.i = i
+          this.observer.observe(entry.item)
+        }
       }
     }
     if (onGetTextSuccess) onGetTextSuccess(textItems);

--- a/src/Page/TextLayerItem.jsx
+++ b/src/Page/TextLayerItem.jsx
@@ -78,7 +78,8 @@ export class TextLayerItemInternal extends PureComponent {
       this.props.onLoadSuccessAlignTextItem()
       return;
     }
-    if(!this.fontFamily){
+
+    if(!this.fontFamily && this.props.str.length > 0){
       this.fontFamily = element.style.fontFamily
       this.loadTextItem()
     } else {
@@ -114,13 +115,15 @@ export class TextLayerItemInternal extends PureComponent {
     return false
   }
 
-  alignTextItem = async(widthBounding) => {
-    const element = this.item;
+  updatedWidth = (width) => {
+    this.actualWidth = width
+    return this
+  }
 
+  alignTextItem = async() => {
+    const element = this.item;
     const { scale, width } = this.props;
-    if(typeof widthBounding !== 'undefined'){
-      this.actualWidth = widthBounding
-    }
+
     const targetWidth = width * scale;  
     let transform = `scaleX(${targetWidth / this.actualWidth})`;
 


### PR DESCRIPTION
Hi! I experienced a lot of layout reflows causing by GetBoundingClientRect and style reads/writes while loading pages >10, so I tried to batch the GetBoundingClientRect calls and separate css reads/writes. 
I added a second option with an IntersectionObserver.