### PR TITLE
[fix]: legacy `renderInteractiveForms` property ignored

### DIFF
--- a/src/Page.jsx
+++ b/src/Page.jsx
@@ -109,7 +109,7 @@ export class PageInternal extends PureComponent {
       onRenderTextLayerError,
       onRenderTextLayerSuccess,
       page,
-      renderForms: renderForms ?? renderInteractiveForms, // For backward compatibility
+      renderForms: renderInteractiveForms ?? renderForms, // For backward compatibility
       rotate: this.rotate,
       scale: this.scale,
     };

--- a/src/Page.spec.jsx
+++ b/src/Page.spec.jsx
@@ -313,6 +313,74 @@ describe('Page', () => {
       expect(instance.current.rotate).toBe(90);
     });
 
+    it('requests page to be rendered with forms when given legacy renderInteractiveForms prop', async () => {
+      const { func: onLoadSuccess, promise: onLoadSuccessPromise } = makeAsyncCallback();
+      const instance = createRef();
+
+      render(
+        <Page
+          onLoadSuccess={onLoadSuccess}
+          renderInteractiveForms={true}
+          pageIndex={0}
+          pdf={pdf}
+          ref={instance}
+        />,
+      );
+
+      await onLoadSuccessPromise;
+
+      expect(instance.current.childContext.renderForms).toBe(true);
+    });
+
+    it('requests page to be rendered with forms when given renderForms prop', async () => {
+      const { func: onLoadSuccess, promise: onLoadSuccessPromise } = makeAsyncCallback();
+      const instance = createRef();
+
+      render(
+        <Page
+          onLoadSuccess={onLoadSuccess}
+          renderForms={true}
+          pageIndex={0}
+          pdf={pdf}
+          ref={instance}
+        />,
+      );
+
+      await onLoadSuccessPromise;
+
+      expect(instance.current.childContext.renderForms).toBe(true);
+    });
+
+    it('requests page to be rendered without forms when given false renderForms prop', async () => {
+      const { func: onLoadSuccess, promise: onLoadSuccessPromise } = makeAsyncCallback();
+      const instance = createRef();
+
+      render(
+        <Page
+          onLoadSuccess={onLoadSuccess}
+          renderForms={false}
+          pageIndex={0}
+          pdf={pdf}
+          ref={instance}
+        />,
+      );
+
+      await onLoadSuccessPromise;
+
+      expect(instance.current.childContext.renderForms).toBe(false);
+    });
+
+    it('requests page to be rendered without forms by default', async () => {
+      const { func: onLoadSuccess, promise: onLoadSuccessPromise } = makeAsyncCallback();
+      const instance = createRef();
+
+      render(<Page onLoadSuccess={onLoadSuccess} pageIndex={0} pdf={pdf} ref={instance} />);
+
+      await onLoadSuccessPromise;
+
+      expect(instance.current.childContext.renderForms).toBe(false);
+    });
+
     it('requests page to be rendered in canvas mode by default', async () => {
       const { func: onLoadSuccess, promise: onLoadSuccessPromise } = makeAsyncCallback();
 


### PR DESCRIPTION
Because of the wrong order of operands in null coalesce operator `renderInteractiveForms` property value was ignored.
This PR fixes the issue and adds few tests.