### PR TITLE
Pass the actual itemIndex to the customTextRenderer

### DIFF
--- a/src/Page/TextLayer.jsx
+++ b/src/Page/TextLayer.jsx
@@ -169,9 +169,9 @@ export class TextLayerInternal extends PureComponent {
         this.endElement.current = end;
 
         if (customTextRenderer) {
-          let itemIndex = 0;
-          textContent.items.forEach((item) => {
-            const child = this.layerElement.current.children[itemIndex];
+          let index = 0;
+          textContent.items.forEach((item, itemIndex) => {
+            const child = this.layerElement.current.children[index];
 
             const content = customTextRenderer({
               itemIndex,
@@ -179,7 +179,7 @@ export class TextLayerInternal extends PureComponent {
             });
 
             child.innerHTML = content;
-            itemIndex += item.str && item.hasEOL ? 2 : 1;
+            index += item.str && item.hasEOL ? 2 : 1;
           });
         }
 


### PR DESCRIPTION
While b8d41fc4229cf953dd55741633adcd443096bce4 has solved the visual issue (🎉), the `itemIndex` which is now passed to the custom text rendered no longer aligns with the one from `textContent`.
In my case, I'm using the custom text renderer to highlight parts of the text and the logic for this is comparing the index of the current rendered item with the index from `textContent`.
So I'd be happy if we could use the "actual" index for the renderer, as it used to be before.