### PR TITLE
Fix rendering broken on some browsers

### DIFF
--- a/src/Page/PageCanvas.jsx
+++ b/src/Page/PageCanvas.jsx
@@ -118,7 +118,7 @@ export class PageCanvasInternal extends PureComponent {
     const renderContext = {
       annotationMode: renderForms ? ANNOTATION_MODE.ENABLE_FORMS : ANNOTATION_MODE.ENABLE,
       get canvasContext() {
-        return canvas.getContext('2d');
+        return canvas.getContext('2d', { willReadFrequently: true });
       },
       viewport: renderViewport,
     };


### PR DESCRIPTION
Fixes rendering broken on some browsers by adding `willReadFrequently: true` to `canvas.getContext()`

Closes #1010

See https://github.com/mozilla/pdf.js/issues/14641#issuecomment-1324961575