### PR TITLE
pdfjs black flicker

### DIFF
--- a/src/Page/PageCanvas.jsx
+++ b/src/Page/PageCanvas.jsx
@@ -54,6 +54,22 @@ export class PageCanvasInternal extends PureComponent {
     }
   }
 
+  hideCanvas = () => {
+    this.setCanvasVisible(false);
+  };
+
+  showCanvas = () => {
+    this.setCanvasVisible(true);
+  };
+
+  setCanvasVisible = (visible) => {
+    const { current: canvas } = this.canvasElement;
+
+    if (canvas) {
+      canvas.style.visibility = visible ? 'visible' : 'hidden';
+    }
+  };
+
   /**
    * Called when a page is rendered successfully.
    */
@@ -109,6 +125,9 @@ export class PageCanvasInternal extends PureComponent {
     const { renderViewport, viewport } = this;
     const { canvasBackground, page, renderForms } = this.props;
 
+    // Hiding the canvas on redraw ensures we get rid of black flickering
+    this.hideCanvas();
+
     canvas.width = renderViewport.width;
     canvas.height = renderViewport.height;
 
@@ -132,7 +151,13 @@ export class PageCanvasInternal extends PureComponent {
     const cancellable = page.render(renderContext);
     this.renderer = cancellable;
 
-    return cancellable.promise.then(this.onRenderSuccess).catch(this.onRenderError);
+    return (
+      cancellable.promise
+        // Show the canvas on success and on errors
+        .then(this.onRenderSuccess)
+        .catch(this.onRenderError)
+        .finally(this.showCanvas)
+    );
   };
 
   render() {
@@ -144,6 +169,7 @@ export class PageCanvasInternal extends PureComponent {
         dir="ltr"
         ref={mergeRefs(canvasRef, this.canvasElement)}
         style={{
+          visibility: 'hidden',
           display: 'block',
           userSelect: 'none',
         }}


### PR DESCRIPTION
See comment in pdfjs viewer code: https://github.com/mozilla/pdf.js/blob/master/web/pdf_page_view.js#L994

We also encountered this issue after adding `alpha: false` to canvas context. On zoom or on load the documents now load in from black (a direct consequence of `alpha: false`). The idea here is to hide the canvas until it loads.

@wojtekmaj Just gonna leave this PR here. Feel free to close and rewrite according to what you think is best :)