### PR TITLE
Add pnpm hoist note to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ pdfjs.GlobalWorkerOptions.workerSrc = new URL(
 ).toString();
 ```
 
+Note: pnpm requires .npmrc with `public-hoist-pattern[]=pdfjs-dist`
+
 <details>
 <summary>See more examples</summary>
 


### PR DESCRIPTION
We need to manually hoist pdfjs-dist when using pnpm package manager.