### PR TITLE
fix(readme): tip to install raw loader with yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Add React-PDF to your project by executing `npm install react-pdf` or `yarn add 
 
 #### Next.js
 
-If you use Next.js, you will need to install `raw-loader` by executing `npm install raw-loader --save-dev` or `yarn add yarn-loader --dev` and add the following to your `next.config.js`:
+If you use Next.js, you will need to install `raw-loader` by executing `npm install raw-loader --save-dev` or `yarn add raw-loader --dev` and add the following to your `next.config.js`:
 
 ```diff
 module.exports = {


### PR DESCRIPTION
just fix the tip to install the correct package name of **raw-loader**, instead of **yarn-loader** 🤣 

PS: yarn-loader doesn't exist in the npm _(I tried, trust me)_ 🤣 