### PR TITLE
add workers in exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "./dist/cjs/Page/AnnotationLayer.css": "./dist/cjs/Page/AnnotationLayer.css",
     "./dist/cjs/Page/TextLayer.css": "./dist/cjs/Page/TextLayer.css",
     "./dist/esm/Page/AnnotationLayer.css": "./dist/esm/Page/AnnotationLayer.css",
-    "./dist/esm/Page/TextLayer.css": "./dist/esm/Page/TextLayer.css"
+    "./dist/esm/Page/TextLayer.css": "./dist/esm/Page/TextLayer.css",
+    "./worker/legacy/pdf.worker.entry.js": "./node_modules/pdfjs-dist/legacy/build/pdf.worker.entry.js",
+    "./worker/pdf.worker.entry.js": "./node_modules/pdfjs-dist/build/pdf.worker.entry.js"
   },
   "scripts": {
     "build": "yarn build-js && yarn copy-styles",


### PR DESCRIPTION
This pull-request addresses an issue with the import of the PDF worker in the "react-pdf" package. Due to recent changes in the package, the previous import path for the PDF worker no longer works. This PR proposes a solution to fix the import of the PDF worker and ensure it works as intended.

*Proposed Changes*

Updated "package.json": In the "package.json" file of the "react-pdf" package, two new export paths have been added to allow access to the PDF worker module:

```
"exports": {
     ....
    "./worker/legacy/pdf.worker.entry.js": "./node_modules/pdfjs-dist/legacy/build/pdf.worker.entry.js",
    "./worker/pdf.worker.entry.js": "./node_modules/pdfjs-dist/build/pdf.worker.entry.js"
},
```

With this change we can do:
```
export const getWorker = () => {
  try {
    return require('react-pdf/worker/legacy/pdf.worker.entry.js');
  } catch (e: unknown) {
    return require('pdfjs-dist/legacy/build/pdf.worker.entry.js');
  }
};

pdfjs.GlobalWorkerOptions.workerSrc = getWorker()
```