### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Check the [sample directory](https://github.com/wojtekmaj/react-pdf/tree/main/sa
 If you want to use annotations (e.g. links) in PDFs rendered by React-PDF, then you would need to include stylesheet necessary for annotations to be correctly displayed like so:
 
 ```ts
-import 'react-pdf/dist/Page/AnnotationLayer.css';
+import 'react-pdf/dist/esm/Page/AnnotationLayer.css';
 ```
 
 ### Support for text layer
@@ -220,7 +220,7 @@ import 'react-pdf/dist/Page/AnnotationLayer.css';
 If you want to use text layer in PDFs rendered by React-PDF, then you would need to include stylesheet necessary for text layer to be correctly displayed like so:
 
 ```ts
-import 'react-pdf/dist/Page/TextLayer.css';
+import 'react-pdf/dist/esm/Page/TextLayer.css';
 ```
 
 ### Support for non-latin characters


### PR DESCRIPTION
- For react-pdf@7.3.3 I get a "module not found error" when adding css imports for AnnotationLayer and Text Layer
- Update path for AnnotationLayer and TextLayer to include "esm" in README