### PR TITLE
Replace root README with a symlink to react-pdf's README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,1 @@
-# react-pdf monorepo
-
-Looking for the react-pdf documentation? It can now be found [here](packages/react-pdf/README.md).
+packages/react-pdf/README.md


### PR DESCRIPTION
Looks like #1671 got lost during a force push 😇 