### PR TITLE
Resolving issue #1424 :  Added arialabels to links

### DIFF
--- a/packages/react-pdf/src/LinkService.ts
+++ b/packages/react-pdf/src/LinkService.ts
@@ -172,6 +172,9 @@ export default class LinkService implements IPDFLinkService {
     link.href = url;
     link.rel = this.externalLinkRel || DEFAULT_LINK_REL;
     link.target = newWindow ? '_blank' : this.externalLinkTarget || '';
+    //This is a temporary solve for the arialabel issue
+    //pdfjs might need to make the change to make it more modular 
+    link.ariaLabel = url; 
   }
 
   getDestinationHash() {


### PR DESCRIPTION
 - I understand that React-PDF does not aim to be a fully-fledged PDF viewer and is only a tool to make one
 - I have checked if this feature request is not already reported

I worked with a team to add arialabels for links embedded onto the pdfs. Solving this can resolve the issue with google lighthouse test where arialabels were missing in link annotations. The code was tested with the vite pdf sample and upon inspecting a link it should have an arialabel attribute now.  

