### PR TITLE
fix: the selection will expand to cover all text

### DIFF
--- a/packages/react-pdf/src/Page/TextLayer.tsx
+++ b/packages/react-pdf/src/Page/TextLayer.tsx
@@ -8,6 +8,7 @@ import warning from 'warning';
 import * as pdfjs from 'pdfjs-dist';
 
 import usePageContext from '../shared/hooks/usePageContext.js';
+import useDocumentContext from '../shared/hooks/useDocumentContext.js';
 import useResolver from '../shared/hooks/useResolver.js';
 import { cancelRunningTask } from '../shared/utils.js';
 
@@ -19,8 +20,10 @@ function isTextItem(item: TextItem | TextMarkedContent): item is TextItem {
 
 export default function TextLayer(): React.ReactElement {
   const pageContext = usePageContext();
+  const documentContext = useDocumentContext();
 
   invariant(pageContext, 'Unable to find Page context.');
+  invariant(documentContext, 'Unable to find Document context.');
 
   const {
     customTextRenderer,
@@ -34,6 +37,8 @@ export default function TextLayer(): React.ReactElement {
     rotate,
     scale,
   } = pageContext;
+
+  const { textLayers } = documentContext;
 
   invariant(page, 'Attempted to load page text content, but no page was specified.');
 
@@ -202,6 +207,8 @@ export default function TextLayer(): React.ReactElement {
           const end = document.createElement('div');
           end.className = 'endOfContent';
           layer.append(end);
+
+          textLayers.set(layer, end);
 
           const layerChildren = layer.querySelectorAll('[role="presentation"]');
 

--- a/packages/react-pdf/src/shared/types.ts
+++ b/packages/react-pdf/src/shared/types.ts
@@ -139,6 +139,7 @@ export type DocumentContextType = {
   renderMode?: RenderMode;
   rotate?: number | null;
   unregisterPage: UnregisterPage;
+  textLayers: Map<HTMLElement, HTMLElement>;
 } | null;
 
 export type PageContextType = {


### PR DESCRIPTION
 In non-Firefox browsers, when hovering over an empty space,  the selection will expand to cover all the text between the current selection and .endOfContent.
 By moving .endOfContent to right after limit the selection jump to at most cover the enteirety of the <span> where the selection is being modified.