### PR TITLE
Fix `Worker was terminated` error on unmount

### DIFF
--- a/packages/react-pdf/src/Document.spec.tsx
+++ b/packages/react-pdf/src/Document.spec.tsx
@@ -696,12 +696,10 @@ describe('Document', () => {
     vi.mocked(globalThis.console.error).mockRestore();
   });
 
-  it('does not throw an error on unmount if loading has not yet finished', async () => {
+  it('does not throw an error on unmount', async () => {
     const { func: onLoadProgress, promise: onLoadProgressPromise } = makeAsyncCallback();
 
-    const { unmount } = render(
-      <Document file={pdfFile} onLoadProgress={onLoadProgress} options={{ stopAtErrors: true }} />,
-    );
+    const { unmount } = render(<Document file={pdfFile} onLoadProgress={onLoadProgress} />);
 
     await onLoadProgressPromise;
 

--- a/packages/react-pdf/src/Document.spec.tsx
+++ b/packages/react-pdf/src/Document.spec.tsx
@@ -695,4 +695,16 @@ describe('Document', () => {
 
     vi.mocked(globalThis.console.error).mockRestore();
   });
+
+  it('does not throw an error on unmount if loading has not yet finished', async () => {
+    const { func: onLoadProgress, promise: onLoadProgressPromise } = makeAsyncCallback();
+
+    const { unmount } = render(
+      <Document file={pdfFile} onLoadProgress={onLoadProgress} options={{ stopAtErrors: true }} />,
+    );
+
+    await onLoadProgressPromise;
+
+    expect(unmount).not.toThrowError();
+  });
 });

--- a/packages/react-pdf/src/Document.tsx
+++ b/packages/react-pdf/src/Document.tsx
@@ -8,6 +8,7 @@ import invariant from 'tiny-invariant';
 import warning from 'warning';
 import { dequal } from 'dequal';
 import * as pdfjs from 'pdfjs-dist';
+import type { DocumentInitParameters } from 'pdfjs-dist/types/src/display/api.js';
 
 import DocumentContext from './DocumentContext.js';
 
@@ -507,10 +508,9 @@ const Document: React.ForwardRefExoticComponent<
         return;
       }
 
-      const documentInitParams: Source = {
-        ...source,
-        ...options,
-      };
+      const documentInitParams: DocumentInitParameters = options
+        ? { ...source, ...options }
+        : source;
 
       const destroyable = pdfjs.getDocument(documentInitParams);
       if (onLoadProgress) {
@@ -521,7 +521,7 @@ const Document: React.ForwardRefExoticComponent<
       }
       const loadingTask = destroyable;
 
-      loadingTask.promise
+      const loadingPromise = loadingTask.promise
         .then((nextPdf) => {
           pdfDispatch({ type: 'RESOLVE', value: nextPdf });
         })
@@ -534,7 +534,7 @@ const Document: React.ForwardRefExoticComponent<
         });
 
       return () => {
-        loadingTask.destroy();
+        loadingPromise.finally(() => loadingTask.destroy());
       };
     },
     [options, pdfDispatch, source],

--- a/packages/react-pdf/src/Document.tsx
+++ b/packages/react-pdf/src/Document.tsx
@@ -8,7 +8,6 @@ import invariant from 'tiny-invariant';
 import warning from 'warning';
 import { dequal } from 'dequal';
 import * as pdfjs from 'pdfjs-dist';
-import type { DocumentInitParameters } from 'pdfjs-dist/types/src/display/api.js';
 
 import DocumentContext from './DocumentContext.js';
 
@@ -31,6 +30,7 @@ import {
 import useResolver from './shared/hooks/useResolver.js';
 
 import type { PDFDocumentProxy } from 'pdfjs-dist';
+import type { DocumentInitParameters } from 'pdfjs-dist/types/src/display/api.js';
 import type { EventProps } from 'make-event-props';
 import type {
   ClassName,


### PR DESCRIPTION
Fixes https://github.com/wojtekmaj/react-pdf/issues/1062 - `Worker was terminated` error on document unmount if loading has not yet finished.
