### PR TITLE
Fix sample/next-app build error

### DIFF
--- a/sample/next-app/app/Sample.tsx
+++ b/sample/next-app/app/Sample.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import "../utils/pdfWorkerPolyfill"
 import { useCallback, useState } from 'react';
 import { useResizeObserver } from '@wojtekmaj/react-hooks';
 import { pdfjs, Document, Page } from 'react-pdf';

--- a/sample/next-app/utils/pdfWorkerPolyfill.ts
+++ b/sample/next-app/utils/pdfWorkerPolyfill.ts
@@ -1,0 +1,25 @@
+"use client";
+
+if (Promise.withResolvers === undefined) {
+  if (typeof window !== "undefined") {
+    // @ts-expect-error This does not exist outside of polyfill which this is doing
+    window.Promise.withResolvers = function () {
+      let resolve, reject;
+      const promise = new Promise((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+      return { promise, resolve, reject };
+    };
+  } else {
+    // @ts-expect-error This does not exist outside of polyfill which this is doing
+    global.Promise.withResolvers = function () {
+      let resolve, reject;
+      const promise = new Promise((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+      return { promise, resolve, reject };
+    };
+  }
+}


### PR DESCRIPTION
# Related issue
close #1907

# Problem
- `Promise.withResolvers` does not exist in Node.js.
- As far as I know, it may have been added to the latest node.js specification, but it is not LTS. (I heard this too, but I couldn't find related information in node.js Docs.)
- So the build fails. (In addition, a 500 status code is received during development.)
```
Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error

TypeError: Promise.withResolvers is not a function
    at 8270 (/Users/nayunsang/Desktop/untitle/jsproject/react/react-pdf/sample/next-app/.next/server/app/page.js:2:58427)
    at Object.t [as require] (/Users/nayunsang/Desktop/untitle/jsproject/react/react-pdf/sample/next-app/.next/server/webpack-runtime.js:1:127)
    at require (/Users/nayunsang/Desktop/untitle/jsproject/react/react-pdf/sample/next-app/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:131:7101)
    at i (/Users/nayunsang/Desktop/untitle/jsproject/react/react-pdf/sample/next-app/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:36:105)
    at l (/Users/nayunsang/Desktop/untitle/jsproject/react/react-pdf/sample/next-app/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:36:528)
    at /Users/nayunsang/Desktop/untitle/jsproject/react/react-pdf/sample/next-app/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:36:20548
...
```

# How to fix
- Add polyfill for `Promise.withResolvers`.
- This prepares for cases where Promise.withResolvers is undefined.

# Result
- The build succeeds.
```
 ✓ Generating static pages (4/4)
 ✓ Collecting build traces    
 ✓ Finalizing page optimization    

Route (app)                              Size     First Load JS
┌ ○ /                                    104 kB          204 kB
└ ○ /_not-found                          897 B           100 kB
+ First Load JS shared by all            99.3 kB
  ├ chunks/215-fb82eb89be3c28ac.js       44.6 kB
  ├ chunks/4bd1b696-d5c73e5fd6d55b87.js  52.6 kB
  └ other shared chunks (total)          2.03 kB
```

# Additional
- If you are not satisfied with the code structure, please leave a comment.