### PR TITLE
Add vite web worker instructions to readme

### DIFF
--- a/packages/react-pdf/README.md
+++ b/packages/react-pdf/README.md
@@ -144,6 +144,21 @@ pdfjs.GlobalWorkerOptions.workerSrc = new URL(
 <details>
 <summary>See more examples</summary>
 
+##### Vite
+
+For Vite, you can use a [query suffix](https://vite.dev/guide/assets#importing-script-as-a-worker) to import [web-workers](https://vite.dev/guide/features.html#web-workers) and bundle as needed:
+
+```diff
+import { pdfjs } from 'react-pdf';
++ import src from 'pdfjs-dist/build/pdf.worker.min.mjs?worker&url';
+
+- pdfjs.GlobalWorkerOptions.workerSrc = new URL(
+-   'pdfjs-dist/build/pdf.worker.min.mjs',
+-   import.meta.url,
+- ).toString();
++ pdfjs.GlobalWorkerOptions.workerSrc = src;
+```
+
 ##### Parcel 2
 
 For Parcel 2, you need to use a slightly different code:


### PR DESCRIPTION
Vite can bundle and import by url web worker source (links to docs in the PR). The current docs have never worked for me with vite and I believe this would be the "right" way to bundle and setup the web worker for react-pdf.

I've added a section to the README to describe how to set up the web worker with vite.

Related to #1843, #967, #1909