### PR TITLE
Add RenderContext in onRenderSuccess

### DIFF
--- a/packages/react-pdf/src/Page/Canvas.spec.tsx
+++ b/packages/react-pdf/src/Page/Canvas.spec.tsx
@@ -66,7 +66,14 @@ describe('Canvas', () => {
 
       expect.assertions(1);
 
-      await expect(onRenderSuccessPromise).resolves.toMatchObject([{}]);
+      await expect(onRenderSuccessPromise).resolves.toMatchObject([
+        {},
+        {
+          annotationMode: 1,
+          canvasContext: expect.any(Object),
+          viewport: page.getViewport({ scale: 1, rotation: 0 }),
+        },
+      ]);
 
       restoreConsole();
     });

--- a/packages/react-pdf/src/Page/Canvas.tsx
+++ b/packages/react-pdf/src/Page/Canvas.tsx
@@ -51,14 +51,14 @@ export default function Canvas(props: CanvasProps): React.ReactElement {
   /**
    * Called when a page is rendered successfully.
    */
-  function onRenderSuccess() {
+  function onRenderSuccess(renderContext: RenderParameters) {
     if (!page) {
       // Impossible, but TypeScript doesn't know that
       return;
     }
 
     if (onRenderSuccessProps) {
-      onRenderSuccessProps(makePageCallback(page, scale));
+      onRenderSuccessProps(makePageCallback(page, scale), renderContext);
     }
   }
 
@@ -126,7 +126,7 @@ export default function Canvas(props: CanvasProps): React.ReactElement {
         .then(() => {
           canvas.style.visibility = '';
 
-          onRenderSuccess();
+          onRenderSuccess(renderContext);
         })
         .catch(onRenderError);
 

--- a/packages/react-pdf/src/shared/types.ts
+++ b/packages/react-pdf/src/shared/types.ts
@@ -8,6 +8,7 @@ import type {
   TypedArray,
   DocumentInitParameters,
   RefProxy,
+  RenderParameters,
   StructTreeNode,
   TextContent,
   TextItem,
@@ -119,7 +120,7 @@ export type OnRenderAnnotationLayerSuccess = () => void;
 
 export type OnRenderError = OnError;
 
-export type OnRenderSuccess = (page: PageCallback) => void;
+export type OnRenderSuccess = (page: PageCallback, renderContext: RenderParameters) => void;
 
 export type OnRenderTextLayerError = OnError;
 


### PR DESCRIPTION
Hi! Thanks for this amazing library!

This PR is just proposing a small addon regarding a issue i faced when building my own pdf viewer on top of react-pdf.

In my case, i need to know the specs that `<Page/>` element renders with, so i can tell whether the rendered version is the version i want. 

Context: i faced the flickering issue when toggling specs like rotate, width, height. 
To fix this, I added sth on top by leveraging on css transform that applied on the 'prev page', to shape it look like the page that about being rendered. (Getting inspirations from here https://github.com/wojtekmaj/react-pdf/issues/418)

However, when i keep toggling the specs of the page, i realized that the `onRenderSuccess` for the outdated specs might still be called.
ie: i quickly toggle it like: {rotate:90, width:100} -> {rotate: 180, width: 200} -> {rotate: 270, width: 200}
the renderSuccess callback for  {rotate: 180, width: 200} might be triggered, even though the specs are already changed to {rotate: 270, width: 200}.

Thus, adding the `renderContext` param in the params will help me to know whether the onRenderSuccess is  for rendering the correct specs.

