### PR TITLE
Add trailing slash to `standardFontDataUrl` in README.md

### DIFF
--- a/packages/react-pdf/README.md
+++ b/packages/react-pdf/README.md
@@ -474,7 +474,7 @@ Alternatively, you could use standard fonts from external CDN:
 import { pdfjs } from 'react-pdf';
 
 const options = {
-  standardFontDataUrl: `https://unpkg.com/pdfjs-dist@${pdfjs.version}/standard_fonts`,
+  standardFontDataUrl: `https://unpkg.com/pdfjs-dist@${pdfjs.version}/standard_fonts/`,
 };
 
 // Inside of React component


### PR DESCRIPTION
In the part of `Support for standard fonts` in README.md, it introduces a way that can set external CDN to fetch the font data. 
It reported an error in my project when using the URL provided and found the request of `standard_fonts` failed. Check out the document of `pdfjs` and find it needs to add trailing slash for the URL in `standardFontDataUrl`. 
Refer to: https://mozilla.github.io/pdf.js/api/draft/module-pdfjsLib.html#~DocumentInitParameters
<img width="1186" alt="image" src="https://github.com/user-attachments/assets/fb8bd3fc-f210-48d6-88fd-61c9f913e229" />

**Test result**
Before:
![image](https://github.com/user-attachments/assets/c34499a9-73e1-4ad1-a107-beee4bbf8deb)

After:
![image](https://github.com/user-attachments/assets/99677faf-adbb-46c6-bf96-5ed5454c5cf3)
