### PR TITLE
Globally install corepack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           node-version: '22'
 
       - name: Enable Corepack
-        run: corepack enable
+        run: npm i -g corepack
 
       - name: Install dependencies
         run: yarn --immutable
@@ -122,7 +122,7 @@ jobs:
           node-version: '22'
 
       - name: Enable Corepack
-        run: corepack enable
+        run: npm i -g corepack
 
       - name: Install dependencies
         run: yarn --immutable

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Enable Corepack
-        run: corepack enable
+        run: npm i -g corepack
 
       - name: Install dependencies
         run: yarn --immutable


### PR DESCRIPTION
Corepack is not going to be distributed with Node.js v25+
TSC vote https://github.com/nodejs/TSC/pull/1697#issuecomment-2737093616

This PR updates the command to globally installing corepack.