### PR TITLE
fix: improve accessibility by replacing anchor with button

### DIFF
--- a/packages/react-pdf/src/OutlineItem.spec.tsx
+++ b/packages/react-pdf/src/OutlineItem.spec.tsx
@@ -88,8 +88,8 @@ describe('OutlineItem', () => {
       renderWithContext(<OutlineItem item={outlineItem} />, { pdf }, { onItemClick });
 
       const item = screen.getAllByRole('listitem')[0] as HTMLElement;
-      const link = getAllByRole(item, 'link')[0] as HTMLAnchorElement;
-      fireEvent.click(link);
+      const button = getAllByRole(item, 'button')[0] as HTMLButtonElement;
+      fireEvent.click(button);
 
       await onItemClickPromise;
 
@@ -106,8 +106,8 @@ describe('OutlineItem', () => {
       );
 
       const item = screen.getAllByRole('listitem')[0] as HTMLElement;
-      const link = getAllByRole(item, 'link')[0] as HTMLAnchorElement;
-      fireEvent.click(link);
+      const button = getAllByRole(item, 'button')[0] as HTMLButtonElement;
+      fireEvent.click(button);
 
       await onItemClickPromise;
 
@@ -117,7 +117,7 @@ describe('OutlineItem', () => {
 
       rerender(<OutlineItem item={outlineItem} />, { pdf }, { onItemClick: onItemClick2 });
 
-      fireEvent.click(link);
+      fireEvent.click(button);
 
       await onItemClickPromise2;
 

--- a/packages/react-pdf/src/OutlineItem.tsx
+++ b/packages/react-pdf/src/OutlineItem.tsx
@@ -1,13 +1,10 @@
+import type { PDFDocumentProxy } from 'pdfjs-dist';
+import type { RefProxy } from 'pdfjs-dist/types/src/display/api.js';
 import invariant from 'tiny-invariant';
-
 import Ref from './Ref.js';
-
 import useCachedValue from './shared/hooks/useCachedValue.js';
 import useDocumentContext from './shared/hooks/useDocumentContext.js';
 import useOutlineContext from './shared/hooks/useOutlineContext.js';
-
-import type { PDFDocumentProxy } from 'pdfjs-dist';
-import type { RefProxy } from 'pdfjs-dist/types/src/display/api.js';
 
 type PDFOutline = Awaited<ReturnType<PDFDocumentProxy['getOutline']>>;
 
@@ -59,7 +56,7 @@ export default function OutlineItem(props: OutlineItemProps): React.ReactElement
     return pageIndex + 1;
   });
 
-  function onClick(event: React.MouseEvent<HTMLAnchorElement>) {
+  function onClick(event: React.MouseEvent<HTMLButtonElement>) {
     event.preventDefault();
 
     invariant(
@@ -105,10 +102,9 @@ export default function OutlineItem(props: OutlineItemProps): React.ReactElement
 
   return (
     <li>
-      {/* biome-ignore lint/a11y/useValidAnchor: We can't provide real href here */}
-      <a href="#" onClick={onClick}>
+      <button type="button" onClick={onClick}>
         {item.title}
-      </a>
+      </button>
       {renderSubitems()}
     </li>
   );

--- a/packages/react-pdf/src/Thumbnail.tsx
+++ b/packages/react-pdf/src/Thumbnail.tsx
@@ -12,6 +12,7 @@ import { isProvided } from './shared/utils.js';
 import type { PageProps } from './Page.js';
 import type { ClassName, OnItemClickArgs } from './shared/types.js';
 
+
 export type ThumbnailProps = Omit<
   PageProps,
   | 'className'
@@ -70,7 +71,7 @@ export default function Thumbnail(props: ThumbnailProps): React.ReactElement {
 
   const pageNumber = pageNumberProps ?? (isProvided(pageIndexProps) ? pageIndexProps + 1 : null);
 
-  function onClick(event: React.MouseEvent<HTMLAnchorElement>) {
+  function onClick(event: React.MouseEvent<HTMLButtonElement>) {
     event.preventDefault();
 
     if (!isProvided(pageIndex) || !pageNumber) {
@@ -95,11 +96,7 @@ export default function Thumbnail(props: ThumbnailProps): React.ReactElement {
   const { className: classNameProps, onItemClick: onItemClickProps, ...pageProps } = props;
 
   return (
-    <a
-      className={clsx('react-pdf__Thumbnail', className)}
-      href={pageNumber ? '#' : undefined}
-      onClick={onClick}
-    >
+    <button type="button" className={clsx('react-pdf__Thumbnail', className)} onClick={onClick}>
       <Page
         {...pageProps}
         _className="react-pdf__Thumbnail__page"
@@ -107,6 +104,6 @@ export default function Thumbnail(props: ThumbnailProps): React.ReactElement {
         renderAnnotationLayer={false}
         renderTextLayer={false}
       />
-    </a>
+    </button>
   );
 }

--- a/packages/react-pdf/src/Thumbnail.tsx
+++ b/packages/react-pdf/src/Thumbnail.tsx
@@ -12,7 +12,6 @@ import { isProvided } from './shared/utils.js';
 import type { PageProps } from './Page.js';
 import type { ClassName, OnItemClickArgs } from './shared/types.js';
 
-
 export type ThumbnailProps = Omit<
   PageProps,
   | 'className'

--- a/test/Test.css
+++ b/test/Test.css
@@ -159,4 +159,6 @@ body {
 
 .Test__container__content__thumbnails .react-pdf__Thumbnail {
   border: 1px solid black;
+  padding: 0;
+  cursor: pointer;
 }


### PR DESCRIPTION
## Summary
  This PR improves accessibility by replacing improper use of anchor elements (`<a>`) with semantic button
  elements (`<button>`) for interactive components that don't navigate to different pages.
  
  No additional button style resets were added as the library expects users to handle styling through the provided className props, maintaining consistency with the existing architecture.

  ## Changes
  - **OutlineItem**: Replaced `<a href="#" onClick={...}>` with `<button type="button" onClick={...}>`
  - **Thumbnail**: Replaced `<a href="#" onClick={...}>` with `<button type="button" onClick={...}>`
  - Updated corresponding test files to use `getAllByRole(item, 'button')` instead of `getAllByRole(item,
  'link')`

  ## Why this change?
  According to [MDN Web Docs on anchor elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#onclick_events)
  
  > Anchor elements are often abused as fake buttons by setting their href to `#` or [javascript:void(0)](https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes/javascript) to prevent the page from refreshing, then listening for their click events.

> These bogus href values cause unexpected behavior when copying/dragging links, opening links in a new tab/window, bookmarking, or when JavaScript is loading, errors, or is disabled. They also convey incorrect semantics to assistive technologies, like screen readers.

> Use a `<button>` instead. In general, you should only use a hyperlink for navigation to a real URL.