### PR TITLE
Add aria-labels to PDF link annotations for accessibility

### DIFF
--- a/packages/react-pdf/src/LinkService.ts
+++ b/packages/react-pdf/src/LinkService.ts
@@ -17,6 +17,7 @@ import invariant from 'tiny-invariant';
 import type { PDFDocumentProxy } from 'pdfjs-dist';
 import type { IPDFLinkService } from 'pdfjs-dist/types/web/interfaces.js';
 import type {
+  Annotations,
   Dest,
   ExternalLinkRel,
   ExternalLinkTarget,
@@ -38,6 +39,7 @@ export default class LinkService implements IPDFLinkService {
   isInPresentationMode: boolean;
   pdfDocument?: PDFDocumentProxy | null;
   pdfViewer?: PDFViewer | null;
+  private annotationContext?: Map<string, any>;
 
   constructor() {
     this.externalLinkEnabled = true;
@@ -46,6 +48,7 @@ export default class LinkService implements IPDFLinkService {
     this.isInPresentationMode = false;
     this.pdfDocument = undefined;
     this.pdfViewer = undefined;
+    this.annotationContext = undefined;
   }
 
   setDocument(pdfDocument: PDFDocumentProxy): void {
@@ -62,6 +65,21 @@ export default class LinkService implements IPDFLinkService {
 
   setExternalLinkTarget(externalLinkTarget?: ExternalLinkTarget): void {
     this.externalLinkTarget = externalLinkTarget;
+  }
+
+  setAnnotationContext(annotations: Annotations): void {
+    this.annotationContext = new Map(
+      annotations
+        .filter(
+          (annotation): annotation is object & { id: unknown } =>
+            annotation != null && typeof annotation === 'object' && 'id' in annotation,
+        )
+        .map((annotation) => [String(annotation.id), annotation]),
+    );
+  }
+
+  clearAnnotationContext(): void {
+    this.annotationContext = undefined;
   }
 
   setHash(): void {
@@ -100,6 +118,13 @@ export default class LinkService implements IPDFLinkService {
     link.href = url;
     link.rel = this.externalLinkRel || DEFAULT_LINK_REL;
     link.target = newWindow ? '_blank' : this.externalLinkTarget || '';
+
+    const elementId = link.getAttribute('data-element-id');
+    const overlaidText = elementId && this.annotationContext?.get(elementId)?.overlaidText;
+    const trimmedText = typeof overlaidText === 'string' ? overlaidText.trim() : '';
+    if (trimmedText) {
+      link.setAttribute('aria-label', trimmedText);
+    }
   }
 
   goToDestination(dest: Dest): Promise<void> {

--- a/packages/react-pdf/src/LinkService.ts
+++ b/packages/react-pdf/src/LinkService.ts
@@ -33,13 +33,13 @@ type PDFViewer = {
 };
 
 export default class LinkService implements IPDFLinkService {
+  annotationContext?: Map<string, Annotations[number]>;
   externalLinkEnabled: boolean;
   externalLinkRel?: ExternalLinkRel;
   externalLinkTarget?: ExternalLinkTarget;
   isInPresentationMode: boolean;
   pdfDocument?: PDFDocumentProxy | null;
   pdfViewer?: PDFViewer | null;
-  private annotationContext?: Map<string, any>;
 
   constructor() {
     this.externalLinkEnabled = true;
@@ -70,10 +70,7 @@ export default class LinkService implements IPDFLinkService {
   setAnnotationContext(annotations: Annotations): void {
     this.annotationContext = new Map(
       annotations
-        .filter(
-          (annotation): annotation is object & { id: unknown } =>
-            annotation != null && typeof annotation === 'object' && 'id' in annotation,
-        )
+        .filter((annotation) => 'id' in annotation)
         .map((annotation) => [String(annotation.id), annotation]),
     );
   }
@@ -121,7 +118,9 @@ export default class LinkService implements IPDFLinkService {
 
     const elementId = link.getAttribute('data-element-id');
     const overlaidText = elementId && this.annotationContext?.get(elementId)?.overlaidText;
+
     const trimmedText = typeof overlaidText === 'string' ? overlaidText.trim() : '';
+
     if (trimmedText) {
       link.setAttribute('aria-label', trimmedText);
     }

--- a/packages/react-pdf/src/Page/AnnotationLayer.tsx
+++ b/packages/react-pdf/src/Page/AnnotationLayer.tsx
@@ -175,8 +175,12 @@ export default function AnnotationLayer(): React.ReactElement {
         viewport: clonedViewport,
       };
 
+      const filteredAnnotations = filterAnnotations
+        ? filterAnnotations({ annotations })
+        : annotations;
+
       const renderParameters: AnnotationLayerParameters = {
-        annotations: filterAnnotations ? filterAnnotations({ annotations }) : annotations,
+        annotations: filteredAnnotations,
         annotationStorage: pdf.annotationStorage,
         div: layer,
         imageResourcesPath,
@@ -188,6 +192,8 @@ export default function AnnotationLayer(): React.ReactElement {
 
       layer.innerHTML = '';
 
+      linkService.setAnnotationContext(filteredAnnotations);
+
       try {
         new pdfjs.AnnotationLayer(annotationLayerParameters).render(renderParameters);
 
@@ -195,6 +201,8 @@ export default function AnnotationLayer(): React.ReactElement {
         onRenderSuccess();
       } catch (error) {
         onRenderError(error);
+      } finally {
+        linkService.clearAnnotationContext();
       }
 
       return () => {


### PR DESCRIPTION
PDF link annotations lack discernible names, causing Lighthouse accessibility warnings and poor screen reader support. (#1424)

This update adds aria-label attributes to links using overlaidText from annotation data:

1. Add `setAnnotationContext`/`clearAnnotationContext` to `LinkService` to store annotation data
2. Set annotation context before rendering annotation layer
3. Use overlaidText from annotations in `addLinkAttributes` to set `aria-label`

**Reproduce:**
1. Load test.pdf in the test page
2. Open DevTools → Elements tab
3. Select an `<a>` element in the annotation layer
4. View ARIA attributes in the Accessibility tab

**Effect:**
- Before: Links have no aria-label, causing Lighthouse warnings
  <img width="774" height="628" alt="ScreenShot_2025-12-30_030309_368" src="https://github.com/user-attachments/assets/fe14da98-ecf7-479c-bcbf-75b88c417a7b" />
- After: Links have aria-label with meaningful text for screen readers
  <img width="775" height="628" alt="ScreenShot_2025-12-30_030045_323" src="https://github.com/user-attachments/assets/41c36293-332a-4094-91cd-8d9d7c810262" />
