### PR TITLE
fix(Page): prevent crash when document fails to load

### DIFF
--- a/packages/react-pdf/src/Page.tsx
+++ b/packages/react-pdf/src/Page.tsx
@@ -370,7 +370,7 @@ export default function Page(props: PageProps): React.ReactElement {
   const pageElement = useRef<HTMLDivElement>(null);
 
   invariant(
-    pdf,
+    pdf !== null && pdf !== undefined,
     'Attempted to load a page, but no document was specified. Wrap <Page /> in a <Document /> or pass explicit `pdf` prop.',
   );
 


### PR DESCRIPTION
## Description

When the Document component fails to load a PDF (e.g., 403 or 404 error), it sets `pdf` to `false`. The Page component was throwing an invariant error when `pdf` was `false`, causing the entire UI to crash even when error handlers were provided.

### The Problem

Users reported that when a document fails to load with an error, the whole UI crashes even though they have error handlers in place:

```jsx
<Document
  file={url}
  onLoadError={() => onFileLoadError?.()}
  error={<div>ERROR</div>}
>
  {numPages && (
    <Page pageNumber={currentPage} ... />
  )}
</Document>
```

### The Fix

Changed the invariant check from:
```javascript
invariant(pdf, '...')
```
to:
```javascript
invariant(pdf !== null && pdf !== undefined, '...')
```

This allows `pdf` to be `false` (indicating a load error) and lets the `renderContent()` function handle it gracefully by showing the error message instead of throwing an error.

### Changes
- Modified the invariant check in Page.tsx to allow `pdf === false`
- The existing error handling in `renderContent()` already handles `pdf === false` correctly

Fixes #2051