### PR TITLE
Upgrade pdfjs-dist to 6.0.227 for latest stable PDF.js support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 
 # Project-generated directories and files
 __screenshots__
+.vitest-attachments
 coverage
 dist
 node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@
 
 # Project-generated directories and files
 __screenshots__
-.vitest-attachments
 coverage
 dist
 node_modules

--- a/packages/react-pdf/package.json
+++ b/packages/react-pdf/package.json
@@ -42,7 +42,7 @@
     "make-cancellable-promise": "^2.0.0",
     "make-event-props": "^2.0.0",
     "merge-refs": "^2.0.0",
-    "pdfjs-dist": "5.4.296",
+    "pdfjs-dist": "6.0.227",
     "tiny-invariant": "^1.0.0",
     "warning": "^4.0.0"
   },

--- a/packages/react-pdf/src/Document.spec.tsx
+++ b/packages/react-pdf/src/Document.spec.tsx
@@ -46,7 +46,7 @@ async function waitForAsync() {
 }
 
 describe('Document', () => {
-  // Object with basic loaded PDF information that shall match after successful loading
+  // Assert public callback fields, not PDF.js internal _pdfInfo properties.
   const desiredLoadedPdf = { numPages: 4 };
   const desiredLoadedPdf2 = { numPages: 5 };
 

--- a/packages/react-pdf/src/Document.spec.tsx
+++ b/packages/react-pdf/src/Document.spec.tsx
@@ -1,16 +1,14 @@
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 import { render } from 'vitest-browser-react';
 import { createRef } from 'react';
 
 import Document from './Document.js';
 import DocumentContext from './DocumentContext.js';
-import { pdfjs } from './index.test.js';
 import Page from './Page.js';
 
 import { loadPDF, makeAsyncCallback, muteConsole, restoreConsole } from '../../../test-utils.js';
 
-import type { PDFDocumentProxy } from 'pdfjs-dist';
 import type LinkService from './LinkService.js';
 import type { ScrollPageIntoViewArgs } from './shared/types.js';
 
@@ -49,16 +47,8 @@ async function waitForAsync() {
 
 describe('Document', () => {
   // Object with basic loaded PDF information that shall match after successful loading
-  const desiredLoadedPdf: Partial<PDFDocumentProxy> = {};
-  const desiredLoadedPdf2: Partial<PDFDocumentProxy> = {};
-
-  beforeAll(async () => {
-    const pdf = await pdfjs.getDocument({ data: pdfFile.arrayBuffer }).promise;
-    desiredLoadedPdf._pdfInfo = pdf._pdfInfo;
-
-    const pdf2 = await pdfjs.getDocument({ data: pdfFile2.arrayBuffer }).promise;
-    desiredLoadedPdf2._pdfInfo = pdf2._pdfInfo;
-  });
+  const desiredLoadedPdf = { numPages: 4 };
+  const desiredLoadedPdf2 = { numPages: 5 };
 
   describe('loading', () => {
     it('loads a file and calls onSourceSuccess and onLoadSuccess callbacks via data URI properly', async () => {

--- a/packages/react-pdf/src/LinkService.ts
+++ b/packages/react-pdf/src/LinkService.ts
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { EventBus, SimpleLinkService } from 'pdfjs-dist/web/pdf_viewer.mjs';
 import invariant from 'tiny-invariant';
 
 import type { PDFDocumentProxy } from 'pdfjs-dist';
@@ -30,78 +31,56 @@ type PDFViewer = {
   scrollPageIntoView: (args: ScrollPageIntoViewArgs) => void;
 };
 
-export default class LinkService {
-  externalLinkEnabled: boolean;
-  externalLinkRel?: ExternalLinkRel;
-  externalLinkTarget?: ExternalLinkTarget;
-  isInPresentationMode: boolean;
-  pdfDocument?: PDFDocumentProxy | null;
-  pdfViewer?: PDFViewer | null;
+export default class LinkService extends SimpleLinkService {
+  declare pdfDocument: PDFDocumentProxy | null;
+  declare pdfViewer: PDFViewer | null;
+
+  #externalLinkRel?: ExternalLinkRel;
+  #externalLinkTarget?: ExternalLinkTarget;
 
   constructor() {
-    this.externalLinkEnabled = true;
-    this.externalLinkRel = undefined;
-    this.externalLinkTarget = undefined;
-    this.isInPresentationMode = false;
-    this.pdfDocument = undefined;
-    this.pdfViewer = undefined;
+    super({ eventBus: new EventBus() });
   }
 
-  setDocument(pdfDocument: PDFDocumentProxy): void {
+  override setDocument(pdfDocument: PDFDocumentProxy): void {
     this.pdfDocument = pdfDocument;
   }
 
-  setViewer(pdfViewer: PDFViewer): void {
+  override setViewer(pdfViewer: PDFViewer): void {
     this.pdfViewer = pdfViewer;
   }
 
   setExternalLinkRel(externalLinkRel?: ExternalLinkRel): void {
-    this.externalLinkRel = externalLinkRel;
+    this.#externalLinkRel = externalLinkRel;
   }
 
   setExternalLinkTarget(externalLinkTarget?: ExternalLinkTarget): void {
-    this.externalLinkTarget = externalLinkTarget;
+    this.#externalLinkTarget = externalLinkTarget;
   }
 
-  setHash(): void {
-    // Intentionally empty
-  }
-
-  setHistory(): void {
-    // Intentionally empty
-  }
-
-  get pagesCount(): number {
+  override get pagesCount(): number {
     return this.pdfDocument ? this.pdfDocument.numPages : 0;
   }
 
-  get page(): number {
+  override get page(): number {
     invariant(this.pdfViewer, 'PDF viewer is not initialized.');
 
     return this.pdfViewer.currentPageNumber || 0;
   }
 
-  set page(value: number) {
+  override set page(value: number) {
     invariant(this.pdfViewer, 'PDF viewer is not initialized.');
 
     this.pdfViewer.currentPageNumber = value;
   }
 
-  get rotation(): number {
-    return 0;
-  }
-
-  set rotation(_value) {
-    // Intentionally empty
-  }
-
-  addLinkAttributes(link: HTMLAnchorElement, url: string, newWindow: boolean): void {
+  override addLinkAttributes(link: HTMLAnchorElement, url: string, newWindow?: boolean): void {
     link.href = url;
-    link.rel = this.externalLinkRel || DEFAULT_LINK_REL;
-    link.target = newWindow ? '_blank' : this.externalLinkTarget || '';
+    link.rel = this.#externalLinkRel || DEFAULT_LINK_REL;
+    link.target = newWindow ? '_blank' : this.#externalLinkTarget || '';
   }
 
-  goToDestination(dest: Dest): Promise<void> {
+  override goToDestination(dest: Dest): Promise<void> {
     return new Promise<ResolvedDest | null>((resolve) => {
       invariant(this.pdfDocument, 'PDF document not loaded.');
 
@@ -155,7 +134,7 @@ export default class LinkService {
     });
   }
 
-  goToPage(pageNumber: number): void {
+  override goToPage(pageNumber: number): void {
     const pageIndex = pageNumber - 1;
 
     invariant(this.pdfViewer, 'PDF viewer is not initialized.');
@@ -171,30 +150,6 @@ export default class LinkService {
     });
   }
 
-  goToXY(): void {
-    // Intentionally empty
-  }
-
-  cachePageRef(): void {
-    // Intentionally empty
-  }
-
-  getDestinationHash(): string {
-    return '#';
-  }
-
-  getAnchorUrl(): string {
-    return '#';
-  }
-
-  executeNamedAction(): void {
-    // Intentionally empty
-  }
-
-  executeSetOCGState(): Promise<void> {
-    return Promise.resolve();
-  }
-
   isPageVisible(): boolean {
     return true;
   }
@@ -205,5 +160,9 @@ export default class LinkService {
 
   navigateTo(dest: Dest): void {
     this.goToDestination(dest);
+  }
+
+  override async executeSetOCGState(): Promise<void> {
+    // Intentionally empty
   }
 }

--- a/packages/react-pdf/src/LinkService.ts
+++ b/packages/react-pdf/src/LinkService.ts
@@ -15,7 +15,6 @@
 import invariant from 'tiny-invariant';
 
 import type { PDFDocumentProxy } from 'pdfjs-dist';
-import type { IPDFLinkService } from 'pdfjs-dist/types/web/interfaces.js';
 import type {
   Dest,
   ExternalLinkRel,
@@ -31,7 +30,7 @@ type PDFViewer = {
   scrollPageIntoView: (args: ScrollPageIntoViewArgs) => void;
 };
 
-export default class LinkService implements IPDFLinkService {
+export default class LinkService {
   externalLinkEnabled: boolean;
   externalLinkRel?: ExternalLinkRel;
   externalLinkTarget?: ExternalLinkTarget;
@@ -192,8 +191,8 @@ export default class LinkService implements IPDFLinkService {
     // Intentionally empty
   }
 
-  executeSetOCGState(): void {
-    // Intentionally empty
+  executeSetOCGState(): Promise<void> {
+    return Promise.resolve();
   }
 
   isPageVisible(): boolean {

--- a/packages/react-pdf/src/Page.spec.tsx
+++ b/packages/react-pdf/src/Page.spec.tsx
@@ -13,7 +13,7 @@ import silentlyFailingPdf from '../../../__mocks__/_silently_failing_pdf.js';
 
 import { loadPDF, makeAsyncCallback, muteConsole, restoreConsole } from '../../../test-utils.js';
 
-import type { PDFDocumentProxy, PDFPageProxy } from 'pdfjs-dist';
+import type { PDFDocumentProxy } from 'pdfjs-dist';
 import type { DocumentContextType, PageCallback } from './shared/types.js';
 
 const pdfFile = await loadPDF('../../__mocks__/_pdf.pdf');
@@ -58,33 +58,18 @@ describe('Page', () => {
   let pdf5: PDFDocumentProxy;
 
   // Object with basic loaded page information that shall match after successful loading
-  const desiredLoadedPage: Partial<PDFPageProxy> = {};
-  const desiredLoadedPage2: Partial<PDFPageProxy> = {};
-  const desiredLoadedPage3: Partial<PDFPageProxy> = {};
+  const desiredLoadedPage = { pageNumber: 1 };
+  const desiredLoadedPage2 = { pageNumber: 2 };
+  const desiredLoadedPage3 = { pageNumber: 1 };
 
   // Callbacks used in registerPage and unregisterPage callbacks
-  let registerPageArguments: [number, HTMLDivElement];
-  let unregisterPageArguments: [number];
+  const registerPageArguments: [number, HTMLDivElement] = [0, expect.any(HTMLDivElement)];
+  const unregisterPageArguments: [number] = [0];
 
   beforeAll(async () => {
     pdf = await pdfjs.getDocument({ data: pdfFile.arrayBuffer }).promise;
 
-    const page = await pdf.getPage(1);
-    desiredLoadedPage._pageIndex = page._pageIndex;
-    desiredLoadedPage._pageInfo = page._pageInfo;
-
-    const page2 = await pdf.getPage(2);
-    desiredLoadedPage2._pageIndex = page2._pageIndex;
-    desiredLoadedPage2._pageInfo = page2._pageInfo;
-
     pdf2 = await pdfjs.getDocument({ data: pdfFile2.arrayBuffer }).promise;
-
-    const page3 = await pdf2.getPage(1);
-    desiredLoadedPage3._pageIndex = page3._pageIndex;
-    desiredLoadedPage3._pageInfo = page3._pageInfo;
-
-    registerPageArguments = [page._pageIndex, expect.any(HTMLDivElement)];
-    unregisterPageArguments = [page._pageIndex];
 
     pdf4 = await pdfjs.getDocument({ data: pdfFile4.arrayBuffer }).promise;
 

--- a/packages/react-pdf/src/Page.spec.tsx
+++ b/packages/react-pdf/src/Page.spec.tsx
@@ -57,7 +57,7 @@ describe('Page', () => {
   let pdf4: PDFDocumentProxy;
   let pdf5: PDFDocumentProxy;
 
-  // Object with basic loaded page information that shall match after successful loading
+  // Assert public callback fields, not PDF.js internal _page* properties.
   const desiredLoadedPage = { pageNumber: 1 };
   const desiredLoadedPage2 = { pageNumber: 2 };
   const desiredLoadedPage3 = { pageNumber: 1 };

--- a/packages/react-pdf/src/Page/AnnotationLayer.tsx
+++ b/packages/react-pdf/src/Page/AnnotationLayer.tsx
@@ -14,7 +14,6 @@ import useResolver from '../shared/hooks/useResolver.js';
 import { cancelRunningTask } from '../shared/utils.js';
 
 import type { AnnotationLayerParameters } from 'pdfjs-dist/types/src/display/annotation_layer.js';
-import type { PDFLinkService } from 'pdfjs-dist/types/web/pdf_link_service.js';
 import type { Annotations } from '../shared/types.js';
 
 export default function AnnotationLayer(): React.ReactElement {
@@ -181,7 +180,7 @@ export default function AnnotationLayer(): React.ReactElement {
         annotationStorage: pdf.annotationStorage,
         div: layer,
         imageResourcesPath,
-        linkService: linkService as unknown as PDFLinkService,
+        linkService,
         page,
         renderForms,
         viewport: clonedViewport,
@@ -189,32 +188,14 @@ export default function AnnotationLayer(): React.ReactElement {
 
       layer.innerHTML = '';
 
-      let cancelled = false;
-
       const cancellable = makeCancellable(
-        new pdfjs.AnnotationLayer({
-          ...annotationLayerParameters,
-          linkService: linkService as unknown as PDFLinkService,
-        }).render(renderParameters),
+        new pdfjs.AnnotationLayer(annotationLayerParameters).render(renderParameters),
       );
       const runningTask = cancellable;
 
-      cancellable.promise
-        .then(() => {
-          if (!cancelled) {
-            onRenderSuccess();
-          }
-        })
-        .catch((error) => {
-          if (!cancelled) {
-            onRenderError(error);
-          }
-        });
+      cancellable.promise.then(onRenderSuccess).catch(onRenderError);
 
-      return () => {
-        cancelled = true;
-        cancelRunningTask(runningTask);
-      };
+      return () => cancelRunningTask(runningTask);
     },
     [
       annotations,

--- a/packages/react-pdf/src/Page/AnnotationLayer.tsx
+++ b/packages/react-pdf/src/Page/AnnotationLayer.tsx
@@ -14,6 +14,7 @@ import useResolver from '../shared/hooks/useResolver.js';
 import { cancelRunningTask } from '../shared/utils.js';
 
 import type { AnnotationLayerParameters } from 'pdfjs-dist/types/src/display/annotation_layer.js';
+import type { PDFLinkService } from 'pdfjs-dist/types/web/pdf_link_service.js';
 import type { Annotations } from '../shared/types.js';
 
 export default function AnnotationLayer(): React.ReactElement {
@@ -180,7 +181,7 @@ export default function AnnotationLayer(): React.ReactElement {
         annotationStorage: pdf.annotationStorage,
         div: layer,
         imageResourcesPath,
-        linkService,
+        linkService: linkService as unknown as PDFLinkService,
         page,
         renderForms,
         viewport: clonedViewport,
@@ -188,17 +189,31 @@ export default function AnnotationLayer(): React.ReactElement {
 
       layer.innerHTML = '';
 
-      try {
-        new pdfjs.AnnotationLayer(annotationLayerParameters).render(renderParameters);
+      let cancelled = false;
 
-        // Intentional immediate callback
-        onRenderSuccess();
-      } catch (error) {
-        onRenderError(error);
-      }
+      const cancellable = makeCancellable(
+        new pdfjs.AnnotationLayer({
+          ...annotationLayerParameters,
+          linkService: linkService as unknown as PDFLinkService,
+        }).render(renderParameters),
+      );
+      const runningTask = cancellable;
+
+      cancellable.promise
+        .then(() => {
+          if (!cancelled) {
+            onRenderSuccess();
+          }
+        })
+        .catch((error) => {
+          if (!cancelled) {
+            onRenderError(error);
+          }
+        });
 
       return () => {
-        // TODO: Cancel running task?
+        cancelled = true;
+        cancelRunningTask(runningTask);
       };
     },
     [

--- a/packages/react-pdf/src/Page/TextLayer.spec.tsx
+++ b/packages/react-pdf/src/Page/TextLayer.spec.tsx
@@ -49,6 +49,7 @@ describe('TextLayer', () => {
   // Loaded page text items
   let desiredTextItems: TextContent['items'];
   let desiredTextItems2: TextContent['items'];
+  let desiredRenderedTextItemCount: number;
 
   beforeAll(async () => {
     const pdf = await pdfjs.getDocument({ data: pdfFile.arrayBuffer }).promise;
@@ -56,6 +57,15 @@ describe('TextLayer', () => {
     page = await pdf.getPage(1);
     const textContent = await page.getTextContent();
     desiredTextItems = textContent.items;
+
+    const layer = document.createElement('div');
+    const textLayer = new pdfjs.TextLayer({
+      container: layer,
+      textContentSource: page.streamTextContent({ includeMarkedContent: true }),
+      viewport: page.getViewport({ scale: 1 }),
+    });
+    await textLayer.render();
+    desiredRenderedTextItemCount = layer.querySelectorAll('[role="presentation"]').length;
 
     page2 = await pdf.getPage(2);
     const textContent2 = await page2.getTextContent();
@@ -150,7 +160,7 @@ describe('TextLayer', () => {
 
       const textItems = getTextItems(container);
 
-      expect(textItems).toHaveLength(desiredTextItems.length);
+      expect(textItems).toHaveLength(desiredRenderedTextItemCount);
     });
 
     it('renders text content properly given customTextRenderer', async () => {
@@ -171,7 +181,7 @@ describe('TextLayer', () => {
 
       const textItems = getTextItems(container);
 
-      expect(textItems).toHaveLength(desiredTextItems.length);
+      expect(textItems).toHaveLength(desiredRenderedTextItemCount);
     });
 
     it('maps textContent items to actual TextLayer children properly', async () => {
@@ -225,7 +235,7 @@ describe('TextLayer', () => {
 
       const textItems = getTextItems(container);
 
-      expect(textItems).toHaveLength(desiredTextItems.length);
+      expect(textItems).toHaveLength(desiredRenderedTextItemCount);
 
       expect(customTextRenderer).toHaveBeenCalledTimes(desiredTextItems.length);
       expect(customTextRenderer).toHaveBeenCalledWith(

--- a/packages/react-pdf/src/Page/TextLayer.spec.tsx
+++ b/packages/react-pdf/src/Page/TextLayer.spec.tsx
@@ -41,6 +41,22 @@ function getTextItems(container: HTMLElement) {
   return wrapper.querySelectorAll('[role="presentation"]');
 }
 
+/**
+ * PDF.js 6 may render more `[role="presentation"]` nodes than `textContent.items.length`
+ * when marked content is included.
+ */
+async function getRenderedTextItemCount(page: PDFPageProxy): Promise<number> {
+  const layer = document.createElement('div');
+  const textLayer = new pdfjs.TextLayer({
+    container: layer,
+    textContentSource: page.streamTextContent({ includeMarkedContent: true }),
+    viewport: page.getViewport({ scale: 1 }),
+  });
+  await textLayer.render();
+
+  return layer.querySelectorAll('[role="presentation"]').length;
+}
+
 describe('TextLayer', () => {
   // Loaded page
   let page: PDFPageProxy;
@@ -58,14 +74,7 @@ describe('TextLayer', () => {
     const textContent = await page.getTextContent();
     desiredTextItems = textContent.items;
 
-    const layer = document.createElement('div');
-    const textLayer = new pdfjs.TextLayer({
-      container: layer,
-      textContentSource: page.streamTextContent({ includeMarkedContent: true }),
-      viewport: page.getViewport({ scale: 1 }),
-    });
-    await textLayer.render();
-    desiredRenderedTextItemCount = layer.querySelectorAll('[role="presentation"]').length;
+    desiredRenderedTextItemCount = await getRenderedTextItemCount(page);
 
     page2 = await pdf.getPage(2);
     const textContent2 = await page2.getTextContent();

--- a/packages/react-pdf/src/Thumbnail.spec.tsx
+++ b/packages/react-pdf/src/Thumbnail.spec.tsx
@@ -51,7 +51,7 @@ describe('Thumbnail', () => {
   let pdf: PDFDocumentProxy;
   let pdf2: PDFDocumentProxy;
 
-  // Object with basic loaded page information that shall match after successful loading
+  // Assert public callback fields, not PDF.js internal _page* properties.
   const desiredLoadedThumbnail = { pageNumber: 1 };
   const desiredLoadedThumbnail2 = { pageNumber: 2 };
   const desiredLoadedThumbnail3 = { pageNumber: 1 };

--- a/packages/react-pdf/src/Thumbnail.spec.tsx
+++ b/packages/react-pdf/src/Thumbnail.spec.tsx
@@ -13,7 +13,7 @@ import silentlyFailingPdf from '../../../__mocks__/_silently_failing_pdf.js';
 
 import { loadPDF, makeAsyncCallback, muteConsole, restoreConsole } from '../../../test-utils.js';
 
-import type { PDFDocumentProxy, PDFPageProxy } from 'pdfjs-dist';
+import type { PDFDocumentProxy } from 'pdfjs-dist';
 import type { DocumentContextType, PageCallback } from './shared/types.js';
 
 const pdfFile = await loadPDF('../../__mocks__/_pdf.pdf');
@@ -52,28 +52,16 @@ describe('Thumbnail', () => {
   let pdf2: PDFDocumentProxy;
 
   // Object with basic loaded page information that shall match after successful loading
-  const desiredLoadedThumbnail: Partial<PDFPageProxy> = {};
-  const desiredLoadedThumbnail2: Partial<PDFPageProxy> = {};
-  const desiredLoadedThumbnail3: Partial<PDFPageProxy> = {};
+  const desiredLoadedThumbnail = { pageNumber: 1 };
+  const desiredLoadedThumbnail2 = { pageNumber: 2 };
+  const desiredLoadedThumbnail3 = { pageNumber: 1 };
 
   const linkService = new LinkService();
 
   beforeAll(async () => {
     pdf = await pdfjs.getDocument({ data: pdfFile.arrayBuffer }).promise;
 
-    const page = await pdf.getPage(1);
-    desiredLoadedThumbnail._pageIndex = page._pageIndex;
-    desiredLoadedThumbnail._pageInfo = page._pageInfo;
-
-    const page2 = await pdf.getPage(2);
-    desiredLoadedThumbnail2._pageIndex = page2._pageIndex;
-    desiredLoadedThumbnail2._pageInfo = page2._pageInfo;
-
     pdf2 = await pdfjs.getDocument({ data: pdfFile2.arrayBuffer }).promise;
-
-    const page3 = await pdf2.getPage(1);
-    desiredLoadedThumbnail3._pageIndex = page3._pageIndex;
-    desiredLoadedThumbnail3._pageInfo = page3._pageInfo;
   });
 
   describe('loading', () => {

--- a/packages/react-pdf/vitest.setup.ts
+++ b/packages/react-pdf/vitest.setup.ts
@@ -1,2 +1,11 @@
+import * as pdfjs from 'pdfjs-dist';
+
+import './src/pdf.worker.entry.js';
+
+pdfjs.GlobalWorkerOptions.workerSrc = new URL(
+  'pdfjs-dist/build/pdf.worker.min.mjs',
+  import.meta.url,
+).toString();
+
 document.body.style.setProperty('--react-pdf-annotation-layer', '1');
 document.body.style.setProperty('--react-pdf-text-layer', '1');

--- a/yarn.lock
+++ b/yarn.lock
@@ -138,90 +138,98 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-android-arm64@npm:0.1.80":
-  version: 0.1.80
-  resolution: "@napi-rs/canvas-android-arm64@npm:0.1.80"
+"@napi-rs/canvas-android-arm64@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@napi-rs/canvas-android-arm64@npm:1.0.0"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-darwin-arm64@npm:0.1.80":
-  version: 0.1.80
-  resolution: "@napi-rs/canvas-darwin-arm64@npm:0.1.80"
+"@napi-rs/canvas-darwin-arm64@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@napi-rs/canvas-darwin-arm64@npm:1.0.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-darwin-x64@npm:0.1.80":
-  version: 0.1.80
-  resolution: "@napi-rs/canvas-darwin-x64@npm:0.1.80"
+"@napi-rs/canvas-darwin-x64@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@napi-rs/canvas-darwin-x64@npm:1.0.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-linux-arm-gnueabihf@npm:0.1.80":
-  version: 0.1.80
-  resolution: "@napi-rs/canvas-linux-arm-gnueabihf@npm:0.1.80"
+"@napi-rs/canvas-linux-arm-gnueabihf@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@napi-rs/canvas-linux-arm-gnueabihf@npm:1.0.0"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-linux-arm64-gnu@npm:0.1.80":
-  version: 0.1.80
-  resolution: "@napi-rs/canvas-linux-arm64-gnu@npm:0.1.80"
+"@napi-rs/canvas-linux-arm64-gnu@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@napi-rs/canvas-linux-arm64-gnu@npm:1.0.0"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-linux-arm64-musl@npm:0.1.80":
-  version: 0.1.80
-  resolution: "@napi-rs/canvas-linux-arm64-musl@npm:0.1.80"
+"@napi-rs/canvas-linux-arm64-musl@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@napi-rs/canvas-linux-arm64-musl@npm:1.0.0"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-linux-riscv64-gnu@npm:0.1.80":
-  version: 0.1.80
-  resolution: "@napi-rs/canvas-linux-riscv64-gnu@npm:0.1.80"
+"@napi-rs/canvas-linux-riscv64-gnu@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@napi-rs/canvas-linux-riscv64-gnu@npm:1.0.0"
   conditions: os=linux & cpu=riscv64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-linux-x64-gnu@npm:0.1.80":
-  version: 0.1.80
-  resolution: "@napi-rs/canvas-linux-x64-gnu@npm:0.1.80"
+"@napi-rs/canvas-linux-x64-gnu@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@napi-rs/canvas-linux-x64-gnu@npm:1.0.0"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-linux-x64-musl@npm:0.1.80":
-  version: 0.1.80
-  resolution: "@napi-rs/canvas-linux-x64-musl@npm:0.1.80"
+"@napi-rs/canvas-linux-x64-musl@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@napi-rs/canvas-linux-x64-musl@npm:1.0.0"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-win32-x64-msvc@npm:0.1.80":
-  version: 0.1.80
-  resolution: "@napi-rs/canvas-win32-x64-msvc@npm:0.1.80"
+"@napi-rs/canvas-win32-arm64-msvc@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@napi-rs/canvas-win32-arm64-msvc@npm:1.0.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/canvas-win32-x64-msvc@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@napi-rs/canvas-win32-x64-msvc@npm:1.0.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas@npm:^0.1.80":
-  version: 0.1.80
-  resolution: "@napi-rs/canvas@npm:0.1.80"
+"@napi-rs/canvas@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@napi-rs/canvas@npm:1.0.0"
   dependencies:
-    "@napi-rs/canvas-android-arm64": "npm:0.1.80"
-    "@napi-rs/canvas-darwin-arm64": "npm:0.1.80"
-    "@napi-rs/canvas-darwin-x64": "npm:0.1.80"
-    "@napi-rs/canvas-linux-arm-gnueabihf": "npm:0.1.80"
-    "@napi-rs/canvas-linux-arm64-gnu": "npm:0.1.80"
-    "@napi-rs/canvas-linux-arm64-musl": "npm:0.1.80"
-    "@napi-rs/canvas-linux-riscv64-gnu": "npm:0.1.80"
-    "@napi-rs/canvas-linux-x64-gnu": "npm:0.1.80"
-    "@napi-rs/canvas-linux-x64-musl": "npm:0.1.80"
-    "@napi-rs/canvas-win32-x64-msvc": "npm:0.1.80"
+    "@napi-rs/canvas-android-arm64": "npm:1.0.0"
+    "@napi-rs/canvas-darwin-arm64": "npm:1.0.0"
+    "@napi-rs/canvas-darwin-x64": "npm:1.0.0"
+    "@napi-rs/canvas-linux-arm-gnueabihf": "npm:1.0.0"
+    "@napi-rs/canvas-linux-arm64-gnu": "npm:1.0.0"
+    "@napi-rs/canvas-linux-arm64-musl": "npm:1.0.0"
+    "@napi-rs/canvas-linux-riscv64-gnu": "npm:1.0.0"
+    "@napi-rs/canvas-linux-x64-gnu": "npm:1.0.0"
+    "@napi-rs/canvas-linux-x64-musl": "npm:1.0.0"
+    "@napi-rs/canvas-win32-arm64-msvc": "npm:1.0.0"
+    "@napi-rs/canvas-win32-x64-msvc": "npm:1.0.0"
   dependenciesMeta:
     "@napi-rs/canvas-android-arm64":
       optional: true
@@ -241,9 +249,15 @@ __metadata:
       optional: true
     "@napi-rs/canvas-linux-x64-musl":
       optional: true
+    "@napi-rs/canvas-win32-arm64-msvc":
+      optional: true
     "@napi-rs/canvas-win32-x64-msvc":
       optional: true
-  checksum: 10c0/41c60ee5cb96571561a6d72a5cebc2bebbc775096ccb0fb7cc06e0665f327d9396dc30740f1466bd91a10147fc5783979570a4dde7530be9e05d88d6fa6a73ae
+    canvas:
+      built: true
+    skia-canvas:
+      built: true
+  checksum: 10c0/ceead8f0039d6d093a09b1f0f2dcb6854ee49e79ff9830465ca3fffa585b698d63a3af69ae735f42de26845073cc03383cf89c2d431af1375198f82e003f54ec
   languageName: node
   linkType: hard
 
@@ -1275,15 +1289,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pdfjs-dist@npm:5.4.296":
-  version: 5.4.296
-  resolution: "pdfjs-dist@npm:5.4.296"
+"pdfjs-dist@npm:6.0.227":
+  version: 6.0.227
+  resolution: "pdfjs-dist@npm:6.0.227"
   dependencies:
-    "@napi-rs/canvas": "npm:^0.1.80"
+    "@napi-rs/canvas": "npm:^1.0.0"
   dependenciesMeta:
     "@napi-rs/canvas":
       optional: true
-  checksum: 10c0/a9e438f12771963f7c29934b4d5e58d508fa43954e4e4cbf951b040c6c89891d048e3d9d3799ed9ec6ceade677628a25f88062b300c5425777ce0b522e457532
+  checksum: 10c0/e364dad374de36e0e746272b05bb01709e164d4e1a90f56915af4af4ae96200dbd6985b5ff8fb25ceabf7699b22d60b0ee862af61723e7aea08771c3ea2f9bc2
   languageName: node
   linkType: hard
 
@@ -1392,7 +1406,7 @@ __metadata:
     make-cancellable-promise: "npm:^2.0.0"
     make-event-props: "npm:^2.0.0"
     merge-refs: "npm:^2.0.0"
-    pdfjs-dist: "npm:5.4.296"
+    pdfjs-dist: "npm:6.0.227"
     playwright: "npm:^1.60.0"
     react: "npm:^19.2.0"
     react-dom: "npm:^19.2.0"


### PR DESCRIPTION
Adapt LinkService, AnnotationLayer, and tests for PDF.js 6 API changes, and configure the Vitest worker so browser tests run reliably.