### PR TITLE
Update pnpm 11+ hoisting instructions

### DIFF
--- a/packages/react-pdf/README.md
+++ b/packages/react-pdf/README.md
@@ -92,7 +92,18 @@ pdfjs.GlobalWorkerOptions.workerSrc = new URL(
 > In Next.js, make sure to skip SSR when importing the module you're using this code in. Here's how to do this in [Pages Router](https://nextjs.org/docs/pages/guides/lazy-loading#with-no-ssr) and [App Router](https://nextjs.org/docs/app/guides/lazy-loading#skipping-ssr).
 
 > [!NOTE]
-> pnpm requires an `.npmrc` file with `public-hoist-pattern[]=pdfjs-dist` for this to work.
+> pnpm requires additional configuration so that `pdfjs-dist` is hoisted to `node_modules`:
+>
+> **pnpm < 11** — add to `.npmrc`:
+> ```
+> public-hoist-pattern[]=pdfjs-dist
+> ```
+>
+> **pnpm 11+** — add to `pnpm-workspace.yaml` (`.npmrc` no longer supports non-auth settings in pnpm 11):
+> ```yaml
+> publicHoistPattern:
+>   - 'pdfjs-dist'
+> ```
 
 <details>
 <summary>See more examples</summary>

--- a/packages/react-pdf/README.md
+++ b/packages/react-pdf/README.md
@@ -92,17 +92,17 @@ pdfjs.GlobalWorkerOptions.workerSrc = new URL(
 > In Next.js, make sure to skip SSR when importing the module you're using this code in. Here's how to do this in [Pages Router](https://nextjs.org/docs/pages/guides/lazy-loading#with-no-ssr) and [App Router](https://nextjs.org/docs/app/guides/lazy-loading#skipping-ssr).
 
 > [!NOTE]
-> pnpm requires additional configuration so that `pdfjs-dist` is hoisted to `node_modules`:
+> pnpm users may need to hoist `pdfjs-dist` for this setup to work:
 >
-> **pnpm < 11** — add to `.npmrc`:
-> ```
+> **pnpm < 11** — add this to `.npmrc`:
+> ```ini
 > public-hoist-pattern[]=pdfjs-dist
 > ```
 >
-> **pnpm 11+** — add to `pnpm-workspace.yaml` (`.npmrc` no longer supports non-auth settings in pnpm 11):
+> **pnpm 11+** — add this to `pnpm-workspace.yaml`:
 > ```yaml
 > publicHoistPattern:
->   - 'pdfjs-dist'
+>   - pdfjs-dist
 > ```
 
 <details>


### PR DESCRIPTION
## Summary

Fixes #2106

pnpm 11 removed support for non-auth settings in `.npmrc` — those settings must now live in `pnpm-workspace.yaml`. The existing note only showed the `.npmrc` approach, which silently does nothing on pnpm 11 (pdfjs-dist ends up only under `node_modules/.pnpm`, not hoisted, breaking the worker import).

## Changes

Expanded the single-line pnpm note to cover both cases side by side:

**pnpm < 11** — `.npmrc` (unchanged):
```
public-hoist-pattern[]=pdfjs-dist
```

**pnpm 11+** — `pnpm-workspace.yaml`:
```yaml
publicHoistPattern:
  - 'pdfjs-dist'
```

No code changes — documentation only.