### PR TITLE
[breaking] Update pdfjs-dist to 6.3.289

### DIFF
--- a/packages/react-pdf/README.md
+++ b/packages/react-pdf/README.md
@@ -44,7 +44,7 @@ Browser compatibility for React-PDF primarily depends on PDF.js support. For det
 
 You may extend the list of supported browsers by providing additional polyfills (e.g. `Array.prototype.at`, `Promise.allSettled` or `Promise.withResolvers`), configuring your bundler to transpile `pdfjs-dist`, and using [legacy PDF.js worker](#legacy-pdfjs-worker).
 
-[PDF.js 6 raises the minimum supported browser versions](https://github.com/mozilla/pdf.js/pull/21152) to Chrome 125 and Safari 18, including when using the legacy build. Older browser versions may fail to load PDF.js modules.
+Legacy PDF.js worker supports Chrome 125 and newer, and Safari 18 and newer. Older browser versions may still fail to load PDF.js modules.
 
 #### React
 

--- a/packages/react-pdf/README.md
+++ b/packages/react-pdf/README.md
@@ -44,7 +44,7 @@ Browser compatibility for React-PDF primarily depends on PDF.js support. For det
 
 You may extend the list of supported browsers by providing additional polyfills (e.g. `Array.prototype.at`, `Promise.allSettled` or `Promise.withResolvers`), configuring your bundler to transpile `pdfjs-dist`, and using [legacy PDF.js worker](#legacy-pdfjs-worker).
 
-Legacy PDF.js worker has been reported to support iOS 16.4 and newer. Older iOS versions may still fail to load PDF.js modules.
+[PDF.js 6 raises the minimum supported browser versions](https://github.com/mozilla/pdf.js/pull/21152) to Chrome 125 and Safari 18, including when using the legacy build. Older browser versions may fail to load PDF.js modules.
 
 #### React
 

--- a/packages/react-pdf/package.json
+++ b/packages/react-pdf/package.json
@@ -42,7 +42,7 @@
     "make-cancellable-promise": "^2.0.0",
     "make-event-props": "^2.0.0",
     "merge-refs": "^2.0.0",
-    "pdfjs-dist": "5.4.296",
+    "pdfjs-dist": "6.3.289",
     "tiny-invariant": "^1.0.0",
     "warning": "^4.0.0"
   },

--- a/packages/react-pdf/src/LinkService.ts
+++ b/packages/react-pdf/src/LinkService.ts
@@ -12,10 +12,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { EventBus, SimpleLinkService } from 'pdfjs-dist/web/pdf_viewer.mjs';
 import invariant from 'tiny-invariant';
 
 import type { PDFDocumentProxy } from 'pdfjs-dist';
-import type { IPDFLinkService } from 'pdfjs-dist/types/web/interfaces.js';
 import type {
   Dest,
   ExternalLinkRel,
@@ -31,78 +31,76 @@ type PDFViewer = {
   scrollPageIntoView: (args: ScrollPageIntoViewArgs) => void;
 };
 
-export default class LinkService implements IPDFLinkService {
-  externalLinkEnabled: boolean;
-  externalLinkRel?: ExternalLinkRel;
-  externalLinkTarget?: ExternalLinkTarget;
-  isInPresentationMode: boolean;
-  pdfDocument?: PDFDocumentProxy | null;
-  pdfViewer?: PDFViewer | null;
+export default class LinkService extends SimpleLinkService {
+  declare pdfDocument: PDFDocumentProxy | null;
+  declare pdfViewer: PDFViewer | null;
+
+  #externalLinkRel?: ExternalLinkRel;
+  #externalLinkTarget?: ExternalLinkTarget;
 
   constructor() {
-    this.externalLinkEnabled = true;
-    this.externalLinkRel = undefined;
-    this.externalLinkTarget = undefined;
-    this.isInPresentationMode = false;
-    this.pdfDocument = undefined;
-    this.pdfViewer = undefined;
+    super({ eventBus: new EventBus() });
   }
 
-  setDocument(pdfDocument: PDFDocumentProxy): void {
+  override setDocument(pdfDocument: PDFDocumentProxy): void {
     this.pdfDocument = pdfDocument;
   }
 
-  setViewer(pdfViewer: PDFViewer): void {
+  override setViewer(pdfViewer: PDFViewer): void {
     this.pdfViewer = pdfViewer;
   }
 
   setExternalLinkRel(externalLinkRel?: ExternalLinkRel): void {
-    this.externalLinkRel = externalLinkRel;
+    this.#externalLinkRel = externalLinkRel;
   }
 
   setExternalLinkTarget(externalLinkTarget?: ExternalLinkTarget): void {
-    this.externalLinkTarget = externalLinkTarget;
+    this.#externalLinkTarget = externalLinkTarget;
   }
 
-  setHash(): void {
+  override setHash(): void {
     // Intentionally empty
   }
 
-  setHistory(): void {
+  override setHistory(): void {
     // Intentionally empty
   }
 
-  get pagesCount(): number {
+  override get isInPresentationMode(): boolean {
+    return false;
+  }
+
+  override get rotation(): number {
+    return 0;
+  }
+
+  override set rotation(_value: number) {
+    // Intentionally empty
+  }
+
+  override get pagesCount(): number {
     return this.pdfDocument ? this.pdfDocument.numPages : 0;
   }
 
-  get page(): number {
+  override get page(): number {
     invariant(this.pdfViewer, 'PDF viewer is not initialized.');
 
     return this.pdfViewer.currentPageNumber || 0;
   }
 
-  set page(value: number) {
+  override set page(value: number) {
     invariant(this.pdfViewer, 'PDF viewer is not initialized.');
 
     this.pdfViewer.currentPageNumber = value;
   }
 
-  get rotation(): number {
-    return 0;
-  }
-
-  set rotation(_value) {
-    // Intentionally empty
-  }
-
-  addLinkAttributes(link: HTMLAnchorElement, url: string, newWindow: boolean): void {
+  override addLinkAttributes(link: HTMLAnchorElement, url: string, newWindow?: boolean): void {
     link.href = url;
-    link.rel = this.externalLinkRel || DEFAULT_LINK_REL;
-    link.target = newWindow ? '_blank' : this.externalLinkTarget || '';
+    link.rel = this.#externalLinkRel || DEFAULT_LINK_REL;
+    link.target = newWindow ? '_blank' : this.#externalLinkTarget || '';
   }
 
-  goToDestination(dest: Dest): Promise<void> {
+  override goToDestination(dest: Dest): Promise<void> {
     return new Promise<ResolvedDest | null>((resolve) => {
       invariant(this.pdfDocument, 'PDF document not loaded.');
 
@@ -156,7 +154,7 @@ export default class LinkService implements IPDFLinkService {
     });
   }
 
-  goToPage(pageNumber: number): void {
+  override goToPage(pageNumber: number): void {
     const pageIndex = pageNumber - 1;
 
     invariant(this.pdfViewer, 'PDF viewer is not initialized.');
@@ -172,7 +170,7 @@ export default class LinkService implements IPDFLinkService {
     });
   }
 
-  goToXY(): void {
+  override goToXY(): void {
     // Intentionally empty
   }
 
@@ -180,19 +178,15 @@ export default class LinkService implements IPDFLinkService {
     // Intentionally empty
   }
 
-  getDestinationHash(): string {
+  override getDestinationHash(): string {
     return '#';
   }
 
-  getAnchorUrl(): string {
+  override getAnchorUrl(): string {
     return '#';
   }
 
-  executeNamedAction(): void {
-    // Intentionally empty
-  }
-
-  executeSetOCGState(): void {
+  override executeNamedAction(): void {
     // Intentionally empty
   }
 
@@ -206,5 +200,9 @@ export default class LinkService implements IPDFLinkService {
 
   navigateTo(dest: Dest): void {
     this.goToDestination(dest);
+  }
+
+  override async executeSetOCGState(): Promise<void> {
+    // Intentionally empty
   }
 }

--- a/packages/react-pdf/src/Page/AnnotationLayer.css
+++ b/packages/react-pdf/src/Page/AnnotationLayer.css
@@ -77,6 +77,16 @@
   transform-origin: 0 0;
 }
 
+.annotationLayer section .overlaidText {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 0;
+  display: inline-block;
+  overflow: hidden;
+}
+
 .annotationLayer .linkAnnotation {
   outline: var(--link-outline);
 }

--- a/packages/react-pdf/src/Page/AnnotationLayer.spec.tsx
+++ b/packages/react-pdf/src/Page/AnnotationLayer.spec.tsx
@@ -197,7 +197,7 @@ describe('AnnotationLayer', () => {
       expect(annotationItems).toHaveLength(desiredAnnotations.length);
     });
 
-    it('calls onRenderAnnotationLayerError when annotation rendering rejects', async () => {
+    it('calls onRenderAnnotationLayerError when failed to render annotations', async () => {
       const error = new Error('Annotation rendering failed');
       const renderAnnotationLayer = vi
         .spyOn(pdfjs.AnnotationLayer.prototype, 'render')

--- a/packages/react-pdf/src/Page/AnnotationLayer.spec.tsx
+++ b/packages/react-pdf/src/Page/AnnotationLayer.spec.tsx
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 
 import DocumentContext from '../DocumentContext.js';
@@ -195,6 +195,30 @@ describe('AnnotationLayer', () => {
       const annotationItems = Array.from(wrapper.children);
 
       expect(annotationItems).toHaveLength(desiredAnnotations.length);
+    });
+
+    it('calls onRenderAnnotationLayerError when annotation rendering rejects', async () => {
+      const error = new Error('Annotation rendering failed');
+      const renderAnnotationLayer = vi
+        .spyOn(pdfjs.AnnotationLayer.prototype, 'render')
+        .mockRejectedValueOnce(error);
+      const { func: onRenderAnnotationLayerError, promise: onRenderAnnotationLayerErrorPromise } =
+        makeAsyncCallback();
+
+      muteConsole();
+
+      try {
+        await renderWithContext(
+          <AnnotationLayer />,
+          { linkService, pdf },
+          { onRenderAnnotationLayerError, page },
+        );
+
+        await expect(onRenderAnnotationLayerErrorPromise).resolves.toEqual([error]);
+      } finally {
+        renderAnnotationLayer.mockRestore();
+        restoreConsole();
+      }
     });
 
     it.each`

--- a/packages/react-pdf/src/Page/AnnotationLayer.tsx
+++ b/packages/react-pdf/src/Page/AnnotationLayer.tsx
@@ -168,7 +168,6 @@ export default function AnnotationLayer(): React.ReactElement {
         annotationStorage: pdf.annotationStorage,
         commentManager: null, // TODO: Implement this
         div: layer,
-        l10n: null, // TODO: Implement this
         linkService,
         page,
         structTreeLayer: null, // TODO: Implement this
@@ -188,18 +187,14 @@ export default function AnnotationLayer(): React.ReactElement {
 
       layer.innerHTML = '';
 
-      try {
-        new pdfjs.AnnotationLayer(annotationLayerParameters).render(renderParameters);
+      const cancellable = makeCancellable(
+        new pdfjs.AnnotationLayer(annotationLayerParameters).render(renderParameters),
+      );
+      const runningTask = cancellable;
 
-        // Intentional immediate callback
-        onRenderSuccess();
-      } catch (error) {
-        onRenderError(error);
-      }
+      cancellable.promise.then(onRenderSuccess).catch(onRenderError);
 
-      return () => {
-        // TODO: Cancel running task?
-      };
+      return () => cancelRunningTask(runningTask);
     },
     [
       annotations,

--- a/packages/react-pdf/src/Page/TextLayer.spec.tsx
+++ b/packages/react-pdf/src/Page/TextLayer.spec.tsx
@@ -36,14 +36,11 @@ async function renderWithContext(children: React.ReactNode, context: Partial<Pag
 }
 
 function getRenderedTextItemCount(items: TextContent['items']) {
-  return items.reduce((count, item) => {
-    if (!('str' in item)) {
-      return count;
-    }
+  const textItems = items.filter((item) => 'str' in item);
+  const spans = textItems.filter((item) => item.str);
+  const lineBreaks = textItems.filter((item) => item.hasEOL);
 
-    // PDF.js renders nonempty text as a span and each line ending as a separate br.
-    return count + Number(Boolean(item.str)) + Number(item.hasEOL);
-  }, 0);
+  return spans.length + lineBreaks.length;
 }
 
 function getTextItems(container: HTMLElement) {

--- a/packages/react-pdf/src/Page/TextLayer.spec.tsx
+++ b/packages/react-pdf/src/Page/TextLayer.spec.tsx
@@ -35,6 +35,17 @@ async function renderWithContext(children: React.ReactNode, context: Partial<Pag
   };
 }
 
+function getRenderedTextItemCount(items: TextContent['items']) {
+  return items.reduce((count, item) => {
+    if (!('str' in item)) {
+      return count;
+    }
+
+    // PDF.js renders nonempty text as a span and each line ending as a separate br.
+    return count + Number(Boolean(item.str)) + Number(item.hasEOL);
+  }, 0);
+}
+
 function getTextItems(container: HTMLElement) {
   const wrapper = container.firstElementChild as HTMLDivElement;
 
@@ -150,7 +161,7 @@ describe('TextLayer', () => {
 
       const textItems = getTextItems(container);
 
-      expect(textItems).toHaveLength(desiredTextItems.length);
+      expect(textItems).toHaveLength(getRenderedTextItemCount(desiredTextItems));
     });
 
     it('renders text content properly given customTextRenderer', async () => {
@@ -171,7 +182,7 @@ describe('TextLayer', () => {
 
       const textItems = getTextItems(container);
 
-      expect(textItems).toHaveLength(desiredTextItems.length);
+      expect(textItems).toHaveLength(getRenderedTextItemCount(desiredTextItems));
     });
 
     it('maps textContent items to actual TextLayer children properly', async () => {
@@ -225,7 +236,7 @@ describe('TextLayer', () => {
 
       const textItems = getTextItems(container);
 
-      expect(textItems).toHaveLength(desiredTextItems.length);
+      expect(textItems).toHaveLength(getRenderedTextItemCount(desiredTextItems));
 
       expect(customTextRenderer).toHaveBeenCalledTimes(desiredTextItems.length);
       expect(customTextRenderer).toHaveBeenCalledWith(

--- a/packages/react-pdf/src/StructTree.spec.tsx
+++ b/packages/react-pdf/src/StructTree.spec.tsx
@@ -138,7 +138,7 @@ describe('StructTree', () => {
       const wrapper = container.firstElementChild as HTMLSpanElement;
 
       expect(wrapper.outerHTML).toBe(
-        '<span class="react-pdf__Page__structTree structTree"><span><span role="heading" aria-level="1" aria-owns="p3R_mc0"></span><span aria-owns="p3R_mc1"></span><span aria-owns="p3R_mc2"></span><span role="figure" aria-owns="p3R_mc12"></span><span aria-owns="p3R_mc3"></span><span aria-owns="p3R_mc4"></span><span role="heading" aria-level="2" aria-owns="p3R_mc5"></span><span aria-owns="p3R_mc6"></span><span><span aria-owns="p3R_mc7"></span><span role="link"><span aria-owns="13R"></span><span aria-owns="p3R_mc8"></span></span><span aria-owns="p3R_mc9"></span></span><span aria-owns="p3R_mc10"></span><span aria-owns="p3R_mc11"></span></span></span>',
+        '<span class="react-pdf__Page__structTree structTree"><span><span role="heading" aria-level="1" aria-owns="p3R_mc0"></span><span aria-owns="p3R_mc1"></span><span aria-owns="p3R_mc2"></span><span role="figure" aria-owns="p3R_mc12"></span><span aria-owns="p3R_mc3"></span><span aria-owns="p3R_mc4"></span><span role="heading" aria-level="2" aria-owns="p3R_mc5"></span><span aria-owns="p3R_mc6"></span><span><span aria-owns="p3R_mc7"></span><span role="link"><span aria-owns="pdfjs_internal_id_13R"></span><span aria-owns="p3R_mc8"></span></span><span aria-owns="p3R_mc9"></span></span><span aria-owns="p3R_mc10"></span><span aria-owns="p3R_mc11"></span></span></span>',
       );
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -155,90 +155,98 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-android-arm64@npm:0.1.80":
-  version: 0.1.80
-  resolution: "@napi-rs/canvas-android-arm64@npm:0.1.80"
+"@napi-rs/canvas-android-arm64@npm:1.0.8":
+  version: 1.0.8
+  resolution: "@napi-rs/canvas-android-arm64@npm:1.0.8"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-darwin-arm64@npm:0.1.80":
-  version: 0.1.80
-  resolution: "@napi-rs/canvas-darwin-arm64@npm:0.1.80"
+"@napi-rs/canvas-darwin-arm64@npm:1.0.8":
+  version: 1.0.8
+  resolution: "@napi-rs/canvas-darwin-arm64@npm:1.0.8"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-darwin-x64@npm:0.1.80":
-  version: 0.1.80
-  resolution: "@napi-rs/canvas-darwin-x64@npm:0.1.80"
+"@napi-rs/canvas-darwin-x64@npm:1.0.8":
+  version: 1.0.8
+  resolution: "@napi-rs/canvas-darwin-x64@npm:1.0.8"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-linux-arm-gnueabihf@npm:0.1.80":
-  version: 0.1.80
-  resolution: "@napi-rs/canvas-linux-arm-gnueabihf@npm:0.1.80"
+"@napi-rs/canvas-linux-arm-gnueabihf@npm:1.0.8":
+  version: 1.0.8
+  resolution: "@napi-rs/canvas-linux-arm-gnueabihf@npm:1.0.8"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-linux-arm64-gnu@npm:0.1.80":
-  version: 0.1.80
-  resolution: "@napi-rs/canvas-linux-arm64-gnu@npm:0.1.80"
+"@napi-rs/canvas-linux-arm64-gnu@npm:1.0.8":
+  version: 1.0.8
+  resolution: "@napi-rs/canvas-linux-arm64-gnu@npm:1.0.8"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-linux-arm64-musl@npm:0.1.80":
-  version: 0.1.80
-  resolution: "@napi-rs/canvas-linux-arm64-musl@npm:0.1.80"
+"@napi-rs/canvas-linux-arm64-musl@npm:1.0.8":
+  version: 1.0.8
+  resolution: "@napi-rs/canvas-linux-arm64-musl@npm:1.0.8"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-linux-riscv64-gnu@npm:0.1.80":
-  version: 0.1.80
-  resolution: "@napi-rs/canvas-linux-riscv64-gnu@npm:0.1.80"
+"@napi-rs/canvas-linux-riscv64-gnu@npm:1.0.8":
+  version: 1.0.8
+  resolution: "@napi-rs/canvas-linux-riscv64-gnu@npm:1.0.8"
   conditions: os=linux & cpu=riscv64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-linux-x64-gnu@npm:0.1.80":
-  version: 0.1.80
-  resolution: "@napi-rs/canvas-linux-x64-gnu@npm:0.1.80"
+"@napi-rs/canvas-linux-x64-gnu@npm:1.0.8":
+  version: 1.0.8
+  resolution: "@napi-rs/canvas-linux-x64-gnu@npm:1.0.8"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-linux-x64-musl@npm:0.1.80":
-  version: 0.1.80
-  resolution: "@napi-rs/canvas-linux-x64-musl@npm:0.1.80"
+"@napi-rs/canvas-linux-x64-musl@npm:1.0.8":
+  version: 1.0.8
+  resolution: "@napi-rs/canvas-linux-x64-musl@npm:1.0.8"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-win32-x64-msvc@npm:0.1.80":
-  version: 0.1.80
-  resolution: "@napi-rs/canvas-win32-x64-msvc@npm:0.1.80"
+"@napi-rs/canvas-win32-arm64-msvc@npm:1.0.8":
+  version: 1.0.8
+  resolution: "@napi-rs/canvas-win32-arm64-msvc@npm:1.0.8"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/canvas-win32-x64-msvc@npm:1.0.8":
+  version: 1.0.8
+  resolution: "@napi-rs/canvas-win32-x64-msvc@npm:1.0.8"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas@npm:^0.1.80":
-  version: 0.1.80
-  resolution: "@napi-rs/canvas@npm:0.1.80"
+"@napi-rs/canvas@npm:^1.0.0":
+  version: 1.0.8
+  resolution: "@napi-rs/canvas@npm:1.0.8"
   dependencies:
-    "@napi-rs/canvas-android-arm64": "npm:0.1.80"
-    "@napi-rs/canvas-darwin-arm64": "npm:0.1.80"
-    "@napi-rs/canvas-darwin-x64": "npm:0.1.80"
-    "@napi-rs/canvas-linux-arm-gnueabihf": "npm:0.1.80"
-    "@napi-rs/canvas-linux-arm64-gnu": "npm:0.1.80"
-    "@napi-rs/canvas-linux-arm64-musl": "npm:0.1.80"
-    "@napi-rs/canvas-linux-riscv64-gnu": "npm:0.1.80"
-    "@napi-rs/canvas-linux-x64-gnu": "npm:0.1.80"
-    "@napi-rs/canvas-linux-x64-musl": "npm:0.1.80"
-    "@napi-rs/canvas-win32-x64-msvc": "npm:0.1.80"
+    "@napi-rs/canvas-android-arm64": "npm:1.0.8"
+    "@napi-rs/canvas-darwin-arm64": "npm:1.0.8"
+    "@napi-rs/canvas-darwin-x64": "npm:1.0.8"
+    "@napi-rs/canvas-linux-arm-gnueabihf": "npm:1.0.8"
+    "@napi-rs/canvas-linux-arm64-gnu": "npm:1.0.8"
+    "@napi-rs/canvas-linux-arm64-musl": "npm:1.0.8"
+    "@napi-rs/canvas-linux-riscv64-gnu": "npm:1.0.8"
+    "@napi-rs/canvas-linux-x64-gnu": "npm:1.0.8"
+    "@napi-rs/canvas-linux-x64-musl": "npm:1.0.8"
+    "@napi-rs/canvas-win32-arm64-msvc": "npm:1.0.8"
+    "@napi-rs/canvas-win32-x64-msvc": "npm:1.0.8"
   dependenciesMeta:
     "@napi-rs/canvas-android-arm64":
       optional: true
@@ -258,9 +266,15 @@ __metadata:
       optional: true
     "@napi-rs/canvas-linux-x64-musl":
       optional: true
+    "@napi-rs/canvas-win32-arm64-msvc":
+      optional: true
     "@napi-rs/canvas-win32-x64-msvc":
       optional: true
-  checksum: 10c0/41c60ee5cb96571561a6d72a5cebc2bebbc775096ccb0fb7cc06e0665f327d9396dc30740f1466bd91a10147fc5783979570a4dde7530be9e05d88d6fa6a73ae
+    canvas:
+      built: true
+    skia-canvas:
+      built: true
+  checksum: 10c0/ebcff2dfbf8f7402aaf5af0f5163a39a84af61e656cf4d1a2d669ea770d15dc27c6dd7d83803daeca39fcdfb609ad548febedf883a9daac14008ecebb95e1ddf
   languageName: node
   linkType: hard
 
@@ -1421,15 +1435,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pdfjs-dist@npm:5.4.296":
-  version: 5.4.296
-  resolution: "pdfjs-dist@npm:5.4.296"
+"pdfjs-dist@npm:6.3.289":
+  version: 6.3.289
+  resolution: "pdfjs-dist@npm:6.3.289"
   dependencies:
-    "@napi-rs/canvas": "npm:^0.1.80"
+    "@napi-rs/canvas": "npm:^1.0.0"
   dependenciesMeta:
     "@napi-rs/canvas":
       optional: true
-  checksum: 10c0/a9e438f12771963f7c29934b4d5e58d508fa43954e4e4cbf951b040c6c89891d048e3d9d3799ed9ec6ceade677628a25f88062b300c5425777ce0b522e457532
+  checksum: 10c0/bb65e7fa9e32a2c2b84f24fb114552fb0e0014ed74bdca5b66005fc7793ff4d27bf66adfbcd8b11a1cdc5705303da8bb08ec24c6b4d823c29e4a4808be89ede2
   languageName: node
   linkType: hard
 
@@ -1538,7 +1552,7 @@ __metadata:
     make-cancellable-promise: "npm:^2.0.0"
     make-event-props: "npm:^2.0.0"
     merge-refs: "npm:^2.0.0"
-    pdfjs-dist: "npm:5.4.296"
+    pdfjs-dist: "npm:6.3.289"
     playwright: "npm:^1.60.0"
     react: "npm:^19.2.0"
     react-dom: "npm:^19.2.0"


### PR DESCRIPTION
Updates the pinned `pdfjs-dist` dependency from 5.4.296 to [6.3.289](https://github.com/mozilla/pdf.js/releases/tag/v6.3.289).

Adapts `LinkService` to PDF.js's concrete link-service type while preserving React-PDF's navigation behavior, waits for asynchronous annotation rendering before firing callbacks, and handles rejected render promises. Adds the annotation overlay text styles required by the new markup and updates text-layer and structure-tree expectations.

Breaking changes from PDF.js include raised browser minimums (Chrome 125 and Safari 18, including the legacy build), Node.js >=22.13.0 or >=24, removal of `PDFDocumentProxy.destroy()` and positional `getDocument` arguments, and changed return types for several APIs exposed through `pdfjs` and document proxies. The README now reflects the browser requirements. See the [6.0 release notes](https://github.com/mozilla/pdf.js/releases/tag/v6.0.227) and subsequent releases for the full API changes.

Validation: `yarn build`, `yarn test`, `yarn workspace test build`, and Biome checks pass. `yarn dedupe` found no duplicates. Existing unused-suppression, Vite peer-dependency, and demo bundle-size warnings remain.

Migration guide: [Upgrade guide from version 10.x to 11.x](https://github.com/wojtekmaj/react-pdf/wiki/Upgrade-guide-from-version-10.x-to-11.x).
