### PR TITLE
[breaking] Require React 19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,8 @@ jobs:
         run: biome lint
 
   typescript:
-    name: Type checking (React ${{ matrix.react }})
+    name: Type checking
     runs-on: ubuntu-24.04-arm
-    strategy:
-      matrix:
-        react: [18, 19]
 
     steps:
       - name: Checkout
@@ -58,18 +55,10 @@ jobs:
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
 
-      - name: Override React version
-        if: ${{ matrix.react == 18 }}
-        run: |
-          npm pkg set resolutions.'@types/react'='npm:^18.0.0'
-          npm pkg set resolutions.'@types/react-dom'='npm:^18.0.0'
-          yarn config set enableImmutableInstalls false
-          yarn up react@^18.0.0 react-dom@^18.0.0
-
       - name: Build package
         run: yarn build
 
-      - name: Run type checking (React ${{ matrix.react }})
+      - name: Run type checking
         run: yarn tsc
 
   format:
@@ -87,11 +76,8 @@ jobs:
         run: biome format
 
   unit:
-    name: Unit tests (React ${{ matrix.react }})
+    name: Unit tests
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        react: [18, 19]
 
     steps:
       - name: Checkout
@@ -126,14 +112,6 @@ jobs:
 
       - name: Install dependencies
         run: yarn --immutable
-
-      - name: Override React version
-        if: ${{ matrix.react == 18 }}
-        run: |
-          npm pkg set resolutions.'@types/react'='npm:^18.0.0'
-          npm pkg set resolutions.'@types/react-dom'='npm:^18.0.0'
-          yarn config set enableImmutableInstalls false
-          yarn up react@^18.0.0 react-dom@^18.0.0
 
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'

--- a/packages/react-pdf/README.md
+++ b/packages/react-pdf/README.md
@@ -48,7 +48,7 @@ Legacy PDF.js worker supports Chrome 125 and newer, and Safari 18 and newer. Old
 
 #### React
 
-To use the latest version of React-PDF, your project needs to use React 16.8 or later.
+To use the latest version of React-PDF, your project needs to use React 19 or later.
 
 #### Preact
 

--- a/packages/react-pdf/package.json
+++ b/packages/react-pdf/package.json
@@ -62,9 +62,9 @@
     "vitest-browser-react": "^2.3.0"
   },
   "peerDependencies": {
-    "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+    "@types/react": "^19.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/packages/react-pdf/src/Document.tsx
+++ b/packages/react-pdf/src/Document.tsx
@@ -644,12 +644,7 @@ const Document: React.ForwardRefExoticComponent<
   }
 
   return (
-    <div
-      className={clsx('react-pdf__Document', className)}
-      // Assertion is needed for React 18 compatibility
-      ref={inputRef as React.Ref<HTMLDivElement>}
-      {...eventProps}
-    >
+    <div className={clsx('react-pdf__Document', className)} ref={inputRef} {...eventProps}>
       {renderContent()}
     </div>
   );

--- a/packages/react-pdf/src/Page.tsx
+++ b/packages/react-pdf/src/Page.tsx
@@ -654,8 +654,7 @@ export default function Page(props: PageProps): React.ReactElement {
     <div
       className={clsx(_className, className)}
       data-page-number={pageNumber}
-      // Assertion is needed for React 18 compatibility
-      ref={mergeRefs(inputRef as React.Ref<HTMLDivElement>, pageElement)}
+      ref={mergeRefs(inputRef, pageElement)}
       style={
         {
           '--scale-round-x': '1px',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1562,9 +1562,9 @@ __metadata:
     vitest-browser-react: "npm:^2.3.0"
     warning: "npm:^4.0.0"
   peerDependencies:
-    "@types/react": ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    "@types/react": ^19.0.0
+    react: ^19.0.0
+    react-dom: ^19.0.0
   peerDependenciesMeta:
     "@types/react":
       optional: true


### PR DESCRIPTION
Require React 19 or later, removing support for React 16.8, 17, and 18. Update the peer dependencies and compatibility documentation, remove the React 18 CI jobs, and remove ref casts needed only for React 18.

Validation: browser tests, package build, type checking, and Biome checks passed. Yarn dedupe produced no package version changes.
